### PR TITLE
Support CSS Color Names, Values, and Keywords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# Maven-specific
+#------------------------------------------------
+/target/
+/dependency-reduced-pom.xml
+
+# Eclipse
+#------------------------------------------------
+.classpath
+.settings/
+.project
+.factorypath
+.apt-generated/
+
+# IntelliJ
+#------------------------------------------------
+*.iml
+*.iws
+*.ipr
+.idea/
+
+# Netbeans
+#------------------------------------------------
+/nbproject
+build/
+nbbuild/
+dist/
+nbdist/
+nbactions.xml
+nb-configuration.xml
+
+# MacOS
+#------------------------------------------------
+.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.github.miachm.sods</groupId>
     <artifactId>SODS</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
 
     <name>Simple ODS library</name>
     <description>A library for load/save ODS files in java.</description>

--- a/src/com/github/miachm/sods/Color.java
+++ b/src/com/github/miachm/sods/Color.java
@@ -1,109 +1,58 @@
 package com.github.miachm.sods;
 
-/** Color is a inmutable class for represent colors.
+/**
+ * Color is an immutable class representing CSS colors. Colors can be specified
+ * in any valid format defined by W3C's CSS Color Module Level 3 specification:
+ * https://www.w3.org/TR/css-color-3/.
+ * 
+ * It should be noted that this class does not validate color names, values, or
+ * keywords (e.g. 'transparent'). Malformed values will be saved as given to
+ * be handled as appropriate by ODS consumers.
+ * 
+ * @author frelling
+ *
  */
-
-final public class Color implements Cloneable {
-    private final int red;
-    private final int green;
-    private final int blue;
-
+public class Color {
+    private final String value;
+    
+    
     /**
-     * It creates a color object from a RGB format (red, green, blue).
-     *
-     * @param red the red color intensity. It must be in a 0-255 range
-     * @param green the green color intensity. It must be in a 0-255 range
-     * @param blue the blue color intensity. It must be in a 0-255 range
+     * Constructs a Color for the given color name or value.
+     * 
+     * @param value CSS color name or hex-color value
      */
-    public Color(int red, int green, int blue) {
-        if (red < 0 || red > 255 ||
-                green < 0 || green > 255 ||
-                blue < 0 || blue > 255)
-            throw new IllegalArgumentException("Error, parameters out of range (0-255)");
-
-        this.red = red;
-        this.green = green;
-        this.blue = blue;
+    public Color(String value) {
+        this.value = value.toLowerCase();
     }
-
-    /**
-     * It creates a color object from a String representation (CSS Style).
-     * The first character is the hashtag '#'
-     * The next two characters are the red intensity in hex (ex: A4)
-     * The next two characters are the green intensity in hex (ex: 3B)
-     * The next two characters are the blue intensity in hex (ex: 53)
-     *
-     * @param hexform The string representation of the color. For example: "#A24C21"
-     * @throws IllegalArgumentException if the string hasn't 7 characters or is ill-formed
-     */
-    public Color(String hexform)
-    {
-        if (hexform.length() != 7) {
-            throw new IllegalArgumentException("Error in Color, the length of the string is not correct (" + hexform.length() + ")");
-        }
-
-        this.red = Integer.valueOf(hexform.substring(1, 3), 16);
-        this.green = Integer.valueOf(hexform.substring(3, 5), 16);
-        this.blue = Integer.valueOf(hexform.substring(5, 7), 16);
-    }
-
-    public int getRed() {
-        return red;
-    }
-
-    public int getBlue() {
-        return blue;
-    }
-
-    public int getGreen() {
-        return green;
-    }
-
-    private static String fill(String text, int len)
-    {
-        int diff = text.length() - len;
-        while (diff < 0) {
-            text = "0" + text;
-            diff++;
-        }
-
-        return text;
-    }
-
-    /**
-     * A string representation of the color
-     *
-     * @return A string of 7 characters with the hex representation of the color (ex: #4a1a4b)
-     */
-
+    
+    
     @Override
-    public String toString()
-    {
-        return "#" + fill(Integer.toHexString(red),2) + fill(Integer.toHexString(green), 2) + fill(Integer.toHexString(blue), 2);
+    public String toString() {
+        return value;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        Color color = (Color) o;
-
-        if (red != color.red) return false;
-        if (blue != color.blue) return false;
-        return green == color.green;
-    }
 
     @Override
     public int hashCode() {
-        int result = red;
-        result = 31 * result + blue;
-        result = 31 * result + green;
-        return result;
+        return 31 + ((value == null) ? 0 : value.hashCode());
     }
 
+
     @Override
-    public Object clone() throws CloneNotSupportedException {
-        return super.clone();
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null || getClass() != obj.getClass())
+            return false;
+
+        Color o = (Color) obj;
+        
+        if (value == null) {
+            if (o.value != null)
+                return false;
+        }
+        else if (!value.equals(o.value))
+            return false;
+        return true;
     }
 }

--- a/tests/com/github/miachm/sods/RangeTest.java
+++ b/tests/com/github/miachm/sods/RangeTest.java
@@ -6,6 +6,9 @@ import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNull;
 
 public class RangeTest {
+    private static final Color COLOR0 = new Color("#020304");
+    private static final Color COLOR1 = new Color("blue");
+    
     @Test
     public void testClear() throws Exception {
         Sheet sheet = new Sheet("A");
@@ -211,8 +214,8 @@ public class RangeTest {
         Range range = sheet.getDataRange();
 
         Style[][] styles = new Style[2][1];
-        styles[0][0] = new Style(true, false, false, null, new Color(2, 3, 4), 4);
-        styles[1][0] = new Style(false, true, true, new Color(200, 100, 230), null, 5);
+        styles[0][0] = new Style(true, false, false, null, COLOR0, 4);
+        styles[1][0] = new Style(false, true, true, COLOR1, null, 5);
         range.setStyles(styles);
 
         Style[][] result = range.getStyles();
@@ -498,21 +501,19 @@ public class RangeTest {
         sheet.appendRow();
         sheet.appendColumn();
 
-        Color color = new Color(240, 23, 45);
-
         Range range = sheet.getDataRange();
-        range.setFontColor(color);
+        range.setFontColor(COLOR0);
 
         Style[][] arr = range.getStyles();
 
-        assertEquals(arr[0][0].getFontColor(),color);
-        assertEquals(arr[0][1].getFontColor(),color);
-        assertEquals(arr[1][0].getFontColor(),color);
-        assertEquals(arr[1][1].getFontColor(),color);
+        assertEquals(arr[0][0].getFontColor(),COLOR0);
+        assertEquals(arr[0][1].getFontColor(),COLOR0);
+        assertEquals(arr[1][0].getFontColor(),COLOR0);
+        assertEquals(arr[1][1].getFontColor(),COLOR0);
 
         range = sheet.getRange(1,0);
-        range.setFontColor(color);
-        assertEquals(range.getStyle().getFontColor(),color);
+        range.setFontColor(COLOR0);
+        assertEquals(range.getStyle().getFontColor(),COLOR0);
     }
 
     @Test
@@ -521,18 +522,15 @@ public class RangeTest {
         sheet.appendRow();
         sheet.appendColumn();
 
-        Color color = new Color(240, 23, 35);
-        Color otherColor = new Color(43, 12, 54);
-
         Range range = sheet.getDataRange();
-        range.setFontColors(otherColor, color, null, otherColor);
+        range.setFontColors(COLOR1, COLOR0, null, COLOR1);
 
         Style[][] arr = range.getStyles();
 
-        assertEquals(arr[0][0].getFontColor(),otherColor);
-        assertEquals(arr[0][1].getFontColor(),color);
+        assertEquals(arr[0][0].getFontColor(),COLOR1);
+        assertEquals(arr[0][1].getFontColor(),COLOR0);
         assertEquals(arr[1][0].getFontColor(),null);
-        assertEquals(arr[1][1].getFontColor(),otherColor);
+        assertEquals(arr[1][1].getFontColor(),COLOR1);
     }
 
     @Test
@@ -542,8 +540,8 @@ public class RangeTest {
         sheet.appendColumn();
 
         Color[][] arr = new Color[2][2];
-        arr[0][1] = new Color(12,23,45);
-        arr[1][1] = new Color(23,45,67);
+        arr[0][1] = COLOR0;
+        arr[1][1] = COLOR1;
 
         Range range = sheet.getDataRange();
         range.setFontColors(arr);
@@ -551,9 +549,9 @@ public class RangeTest {
         Style[][] result = range.getStyles();
 
         assertEquals(result[0][0].getFontColor(),null);
-        assertEquals(result[0][1].getFontColor(),new Color(12, 23, 45));
+        assertEquals(result[0][1].getFontColor(),COLOR0);
         assertEquals(result[1][0].getFontColor(),null);
-        assertEquals(result[1][1].getFontColor(),new Color(23, 45, 67));
+        assertEquals(result[1][1].getFontColor(),COLOR1);
     }
 
     @Test
@@ -562,21 +560,19 @@ public class RangeTest {
         sheet.appendRow();
         sheet.appendColumn();
 
-        Color color = new Color(240, 23, 45);
-
         Range range = sheet.getDataRange();
-        range.setBackgroundColor(color);
+        range.setBackgroundColor(COLOR0);
 
         Style[][] arr = range.getStyles();
 
-        assertEquals(arr[0][0].getBackgroundColor(),color);
-        assertEquals(arr[0][1].getBackgroundColor(),color);
-        assertEquals(arr[1][0].getBackgroundColor(),color);
-        assertEquals(arr[1][1].getBackgroundColor(),color);
+        assertEquals(arr[0][0].getBackgroundColor(),COLOR0);
+        assertEquals(arr[0][1].getBackgroundColor(),COLOR0);
+        assertEquals(arr[1][0].getBackgroundColor(),COLOR0);
+        assertEquals(arr[1][1].getBackgroundColor(),COLOR0);
 
         range = sheet.getRange(1,0);
-        range.setBackgroundColor(color);
-        assertEquals(range.getStyle().getBackgroundColor(),color);
+        range.setBackgroundColor(COLOR0);
+        assertEquals(range.getStyle().getBackgroundColor(),COLOR0);
     }
 
     @Test
@@ -585,18 +581,15 @@ public class RangeTest {
         sheet.appendRow();
         sheet.appendColumn();
 
-        Color color = new Color(240, 23, 35);
-        Color otherColor = new Color(43, 12, 54);
-
         Range range = sheet.getDataRange();
-        range.setBackgroundColors(otherColor, color, null, otherColor);
+        range.setBackgroundColors(COLOR1, COLOR0, null, COLOR1);
 
         Style[][] arr = range.getStyles();
 
-        assertEquals(arr[0][0].getBackgroundColor(),otherColor);
-        assertEquals(arr[0][1].getBackgroundColor(),color);
+        assertEquals(arr[0][0].getBackgroundColor(),COLOR1);
+        assertEquals(arr[0][1].getBackgroundColor(),COLOR0);
         assertEquals(arr[1][0].getBackgroundColor(),null);
-        assertEquals(arr[1][1].getBackgroundColor(),otherColor);
+        assertEquals(arr[1][1].getBackgroundColor(),COLOR1);
     }
 
     @Test
@@ -606,8 +599,8 @@ public class RangeTest {
         sheet.appendColumn();
 
         Color[][] arr = new Color[2][2];
-        arr[0][1] = new Color(12,23,45);
-        arr[1][1] = new Color(23,45,67);
+        arr[0][1] = COLOR0;
+        arr[1][1] = COLOR1;
 
         Range range = sheet.getDataRange();
         range.setBackgroundColors(arr);
@@ -615,9 +608,9 @@ public class RangeTest {
         Style[][] result = range.getStyles();
 
         assertEquals(result[0][0].getBackgroundColor(),null);
-        assertEquals(result[0][1].getBackgroundColor(),new Color(12, 23, 45));
+        assertEquals(result[0][1].getBackgroundColor(),COLOR0);
         assertEquals(result[1][0].getBackgroundColor(),null);
-        assertEquals(result[1][1].getBackgroundColor(),new Color(23, 45, 67));
+        assertEquals(result[1][1].getBackgroundColor(),COLOR1);
     }
 
     @Test
@@ -753,7 +746,7 @@ public class RangeTest {
 
         Style style = new Style();
         style.setFontSize(4);
-        style.setBackgroundColor(new Color(255,0,0));
+        style.setBackgroundColor(COLOR0);
         style.setBold(true);
 
         Range range = sheet.getDataRange();
@@ -775,13 +768,13 @@ public class RangeTest {
 
         Style style = new Style();
         style.setFontSize(4);
-        style.setBackgroundColor(new Color(255,0,0));
+        style.setBackgroundColor(COLOR0);
         style.setBold(true);
 
         Style otherStyle = new Style();
         otherStyle.setUnderline(true);
         otherStyle.setItalic(true);
-        otherStyle.setFontColor(new Color(0,23,12));
+        otherStyle.setFontColor(COLOR1);
 
         Range range = sheet.getDataRange();
         range.setValues(style,new Style(),otherStyle,style);
@@ -802,13 +795,13 @@ public class RangeTest {
 
         Style style = new Style();
         style.setFontSize(4);
-        style.setBackgroundColor(new Color(255,0,0));
+        style.setBackgroundColor(COLOR0);
         style.setBold(true);
 
         Style otherStyle = new Style();
         otherStyle.setUnderline(true);
         otherStyle.setItalic(true);
-        otherStyle.setFontColor(new Color(0,23,12));
+        otherStyle.setFontColor(COLOR1);
 
         Range range = sheet.getDataRange();
         Style[][] arr = new Style[2][3];

--- a/tests/com/github/miachm/sods/SpreadSheetTest.java
+++ b/tests/com/github/miachm/sods/SpreadSheetTest.java
@@ -10,6 +10,9 @@ import java.util.*;
 import static org.testng.AssertJUnit.*;
 
 public class SpreadSheetTest {
+    private static final Color COLOR0 = new Color("#FF0000");
+    private static final Color COLOR1 = new Color("#ffff00");
+    private static final Color COLOR2 = new Color("#ff0203");
 
     private SpreadSheet generateASpreadsheet(){
         SpreadSheet spread = new SpreadSheet();
@@ -298,7 +301,7 @@ public class SpreadSheetTest {
         assertEquals(styles[1][0].getFontColor(), null);
         assertEquals(styles[1][1].getFontColor(), null);
         assertEquals(styles[1][2].getFontColor(), null);
-        assertEquals(styles[1][3].getFontColor(), new Color(255, 0 , 0));
+        assertEquals(styles[1][3].getFontColor(), COLOR0);
         assertEquals(styles[1][4].getFontColor(), null);
         assertEquals(styles[2][0].getFontColor(), null);
         assertEquals(styles[2][1].getFontColor(), null);
@@ -315,7 +318,7 @@ public class SpreadSheetTest {
         assertEquals(styles[1][1].getBackgroundColor(), null);
         assertEquals(styles[1][2].getBackgroundColor(), null);
         assertEquals(styles[1][3].getBackgroundColor(), null);
-        assertEquals(styles[1][4].getBackgroundColor(), new Color("#ffff00"));
+        assertEquals(styles[1][4].getBackgroundColor(), COLOR1);
         assertEquals(styles[2][0].getFontColor(), null);
         assertEquals(styles[2][1].getFontColor(), null);
         assertEquals(styles[2][2].getFontColor(), null);
@@ -362,7 +365,7 @@ public class SpreadSheetTest {
         dataRange.setFontBold(true);
         dataRange.setFontUnderline(true);
         dataRange.setFontColors(new Color("#43a2f5"));
-        dataRange.setBackgroundColor(new Color(255,2,3));
+        dataRange.setBackgroundColor(COLOR2);
         dataRange.setFontSize(18);
 
         dataRange = spread.getSheet(2).getDataRange();

--- a/tests/com/github/miachm/sods/SpreadSheetTest.java
+++ b/tests/com/github/miachm/sods/SpreadSheetTest.java
@@ -374,7 +374,7 @@ public class SpreadSheetTest {
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         spread.save(out);
-        spread.save(new File("example.ods"));
+        spread.save(new File("target/example.ods"));
 
         byte buff[] = out.toByteArray();
         SpreadSheet loaded = new SpreadSheet(new ByteArrayInputStream(buff));


### PR DESCRIPTION
The current Color class implementation is too restrictive and only supports CSS color values (e.g. `#45004A`). This contribution adds the following:

* Relaxes color value checks. Color values, names, and keywords are saved as is in lowercase to normalize values.
* Color supports keywords such as `transparent` (this drove the release of this update) and others as  they are specified in W3C's [CSS Color Module Level 3 Specification](https://www.w3.org/TR/css-color-3/) or future versions.
* Unit tests have been updated to use new Color class and slightly streamlined (i.e. declaring test colors as static elements for reuse by all tests.
* Unit test artifacts are now created under `target/` outside the scope of revision control.
* `.gitignore` has been updated to handle most common local IDE artifacts.

Best regards,
frelling