### PR TITLE
added minimum configuration for java9 modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,15 +6,15 @@
     <groupId>com.github.miachm.sods</groupId>
     <artifactId>SODS</artifactId>
     <packaging>jar</packaging>
-    <version>1.2.1</version>
+    <version>1.3.0</version>
 
     <name>Simple ODS library</name>
     <description>A library for load/save ODS files in java.</description>
     <url>https://github.com/miachm/SODS</url>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>9</maven.compiler.source>
+        <maven.compiler.target>9</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/src/com/github/miachm/sods/module-info.java
+++ b/src/com/github/miachm/sods/module-info.java
@@ -1,0 +1,4 @@
+module SODS {
+    requires java.xml;
+    exports com.github.miachm.sods;
+}


### PR DESCRIPTION
I need this modified version to use the library in a java14 modular application (so I can use jlink and jpackage easily).
Do you think this can be useful also for other developers?
The version number is obviously arbitrary.