### PR TITLE
Add module-info & multi-release build script

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,55 @@
 
     <profiles>
         <profile>
+          <id>jdk9</id>
+          <activation>
+            <jdk>[9,)</jdk>
+          </activation>
+          <build>
+            <pluginManagement>
+              <plugins>
+                <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-compiler-plugin</artifactId>
+                  <executions>
+                    <execution>
+                      <id>jdk9</id>
+                      <goals>
+                        <goal>compile</goal>
+                      </goals>
+                      <configuration>
+                        <source>9</source>
+                        <target>9</target>
+                        <release>9</release>
+                        <compileSourceRoots>
+                          <compileSourceRoot>${project.basedir}/src9</compileSourceRoot>
+                        </compileSourceRoots>
+                        <multiReleaseOutput>true</multiReleaseOutput>
+                      </configuration>
+                    </execution>
+                  </executions>
+                </plugin>
+                <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-jar-plugin</artifactId>
+                  <executions>
+                    <execution>
+                      <id>default-jar</id>
+                      <configuration>
+                        <archive>
+                          <manifestEntries>
+                            <Multi-Release>true</Multi-Release>
+                          </manifestEntries>
+                        </archive>
+                      </configuration>
+                    </execution>
+                  </executions>
+                </plugin>
+              </plugins>
+            </pluginManagement>
+          </build>
+        </profile>
+        <profile>
             <id>Release</id>
             <build>
                 <plugins>

--- a/src9/module-info.java
+++ b/src9/module-info.java
@@ -1,0 +1,4 @@
+module com.github.miachm.sods {
+  requires java.xml;
+  exports com.github.miachm.sods;
+}


### PR DESCRIPTION
This PR combines the module-info from https://github.com/miachm/SODS/pull/14 and the multi-release POM config from this example project https://github.com/apache/maven-compiler-plugin/tree/master/src/it/multirelease-patterns/singleproject-runtime. The published artefacts should be built on Java 9+ in order to obtain the module-info.class.