### PR TITLE
Changed String writing to use "office:value-type" and "office:value" …

### DIFF
--- a/src/com/github/miachm/sods/OfficeValueType.java
+++ b/src/com/github/miachm/sods/OfficeValueType.java
@@ -170,7 +170,7 @@ enum OfficeValueType {
         public void write(Object value, XMLStreamWriter writer) throws XMLStreamException {
             if (value instanceof String) {
                 writer.writeAttribute("office:value-type", this.getId());
-                writer.writeAttribute("office:value", (String)value);
+                writer.writeAttribute("office:string-value", (String)value);
             }
         }
     },

--- a/src/com/github/miachm/sods/OfficeValueType.java
+++ b/src/com/github/miachm/sods/OfficeValueType.java
@@ -168,7 +168,10 @@ enum OfficeValueType {
 
         @Override
         public void write(Object value, XMLStreamWriter writer) throws XMLStreamException {
-            // write as text instead of attribute
+            if (value instanceof String) {
+                writer.writeAttribute("office:value-type", this.getId());
+                writer.writeAttribute("office:value", (String)value);
+            }
         }
     },
     TIME("time", Duration.class) {


### PR DESCRIPTION
…to make them compatible with MS Excel

MS Excel appears to require the use of these, otherwise it will not load strings from the document. Opening and saving in libreoffice will add these attributes.
It will also complain that the document is corrupted, though this appears to also be because it requires styles.xml to be present in the document package
