### PR TITLE
String writing excel compatibility

### DIFF
--- a/src/com/github/miachm/sods/OfficeValueType.java
+++ b/src/com/github/miachm/sods/OfficeValueType.java
@@ -168,7 +168,10 @@ enum OfficeValueType {
 
         @Override
         public void write(Object value, XMLStreamWriter writer) throws XMLStreamException {
-            // write as text instead of attribute
+            writer.writeAttribute("office:value-type", this.getId());
+           // writer.writeAttribute("office:value", (String)value);
+            writer.writeAttribute("office:string-value", (String)value);
+
         }
     },
     TIME("time", Duration.class) {

--- a/src/com/github/miachm/sods/OfficeValueType.java
+++ b/src/com/github/miachm/sods/OfficeValueType.java
@@ -168,10 +168,10 @@ enum OfficeValueType {
 
         @Override
         public void write(Object value, XMLStreamWriter writer) throws XMLStreamException {
-            writer.writeAttribute("office:value-type", this.getId());
-           // writer.writeAttribute("office:value", (String)value);
-            writer.writeAttribute("office:string-value", (String)value);
-
+            if (value instanceof String) {
+                writer.writeAttribute("office:value-type", this.getId());
+                writer.writeAttribute("office:string-value", (String)value);
+            }
         }
     },
     TIME("time", Duration.class) {


### PR DESCRIPTION
Opening produced ods files in MS Excel resulted in corrupted data and strings coming out as blank

Changed the way Strings are output ( using office:value-type="string" and office:string-value="") to improve compatibility.

Using value-type = string and string-value seems to be correct according to the spec for ods files