### PR TITLE
Default currency when office:currency is null

### DIFF
--- a/src/com/github/miachm/sods/OfficeValueType.java
+++ b/src/com/github/miachm/sods/OfficeValueType.java
@@ -47,7 +47,12 @@ enum OfficeValueType {
         @Override
         public Object read(XmlReaderInstance reader) {
             String tag = reader.getAttribValue("office:currency");
-            Currency currency = Currency.getInstance(tag);
+            Currency currency;
+			if (tag == null) {
+				currency = Currency.getInstance(Locale.getDefault());
+			} else {
+				currency = Currency.getInstance(tag);
+			}
 
             NumberFormat nf = NumberFormat.getInstance(Locale.US);
             Double value = null;


### PR DESCRIPTION
Microsoft Excel doesn't provide office:currency tag for currency cell type. It throws NullPointerException when retrieve Currency object. In this case, use the system default currency