### PR TITLE
simplify pom, OSGi manifest, organise Import

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -1,2 +1,0 @@
-Manifest-Version: 1.0
-

--- a/pom.xml
+++ b/pom.xml
@@ -59,71 +59,34 @@
         <sourceDirectory>${project.basedir}/src/</sourceDirectory>
         <testSourceDirectory>${project.basedir}/tests/</testSourceDirectory>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>3.1.2</version>
-                <configuration>
-                    <archive>
-                        <manifestEntries>
-                            <Automatic-Module-Name>com.github.miachm.sods</Automatic-Module-Name>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
-            </plugin>
+        <plugin>
+            <groupId>biz.aQute.bnd</groupId>
+            <artifactId>bnd-maven-plugin</artifactId>
+            <version>6.4.0</version>
+            <configuration>
+            <bnd><![CDATA[
+            Export-Package:\
+                com.github.miachm.sods*
+            
+            Bundle-SymbolicName: com.github.miachm.sods
+            Automatic-Module-Name: com.github.miachm.sods
+            -jpms-module-info: com.github.miachm.sods
+            ]]></bnd>
+            </configuration>
+            <extensions>true</extensions>
+            <executions>
+                <execution>
+                    <id>jar</id>
+                    <goals>
+                        <goal>jar</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
         </plugins>
     </build>
 
     <profiles>
-        <profile>
-          <id>jdk9</id>
-          <activation>
-            <jdk>[9,)</jdk>
-          </activation>
-          <build>
-            <pluginManagement>
-              <plugins>
-                <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-compiler-plugin</artifactId>
-                  <executions>
-                    <execution>
-                      <id>jdk9</id>
-                      <goals>
-                        <goal>compile</goal>
-                      </goals>
-                      <configuration>
-                        <source>9</source>
-                        <target>9</target>
-                        <release>9</release>
-                        <compileSourceRoots>
-                          <compileSourceRoot>${project.basedir}/src9</compileSourceRoot>
-                        </compileSourceRoots>
-                        <multiReleaseOutput>true</multiReleaseOutput>
-                      </configuration>
-                    </execution>
-                  </executions>
-                </plugin>
-                <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-jar-plugin</artifactId>
-                  <executions>
-                    <execution>
-                      <id>default-jar</id>
-                      <configuration>
-                        <archive>
-                          <manifestEntries>
-                            <Multi-Release>true</Multi-Release>
-                          </manifestEntries>
-                        </archive>
-                      </configuration>
-                    </execution>
-                  </executions>
-                </plugin>
-              </plugins>
-            </pluginManagement>
-          </build>
-        </profile>
         <profile>
             <id>Release</id>
             <build>

--- a/src/com/github/miachm/sods/Sheet.java
+++ b/src/com/github/miachm/sods/Sheet.java
@@ -1,6 +1,5 @@
 package com.github.miachm.sods;
 
-import java.lang.reflect.InvocationTargetException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;

--- a/src9/module-info.java
+++ b/src9/module-info.java
@@ -1,4 +1,0 @@
-module com.github.miachm.sods {
-  requires java.xml;
-  exports com.github.miachm.sods;
-}


### PR DESCRIPTION
# removed unused Import
Class: `Sheet.java`
Import: `import java.lang.reflect.InvocationTargetException;`

# calculate MANIFEST.MF for OSGi-Support
MANIFEST.MF is now calculated with `bnd-maven-plugin`
removed MANIFEST.MF
```
Manifest-Version: 1.0
```

calculated MANIFEST.MF :
```
Manifest-Version: 1.0
Automatic-Module-Name>com.github.miachm.sods
Bnd-LastModified: 1676575782683
Bundle-Description: A library for load/save ODS files in java.
Bundle-DocURL: https://github.com/miachm/SODS
Bundle-License: "The Apache License, Version 2.0";link="http://www.apa
 che.org/licenses/LICENSE-2.0.txt"
Bundle-ManifestVersion: 2
Bundle-Name: Simple ODS library
Bundle-SCM: url="https://github.com/miachm/SODS",connection="scm:git:g
 it://github.com/miachm/SODS.git",developer-connection="scm:git:ssh://
 github.com/miachm/SODS.git",tag=HEAD
Bundle-SymbolicName: com.github.miachm.sods
Bundle-Version: 1.5.2
Created-By: 17.0.4.1 (Eclipse Adoptium)
Export-Package: com.github.miachm.sods;version="1.5.2"
Import-Package: javax.xml.namespace,javax.xml.stream
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
Tool: Bnd-6.4.0.202211291949
```

# calculate/fix module-info.class
removed profile `jdk9`
`module-info.class` is now calculated with `bnd-maven-plugin`

removed `module-info.class`
```
module com.github.miachm.sods {
  requires java.xml;
  exports com.github.miachm.sods;
}
```

calculated `module-info.class`
```
open module com.github.miachm.sods {
  requires java.base;
  requires java.xml;
  
  exports com.github.miachm.sods;
}
```
