### PR TITLE
Line breaks issue and naming fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.github.miachm.sods</groupId>
     <artifactId>SODS</artifactId>
     <packaging>jar</packaging>
-    <version>1.5.2</version>
+    <version>1.5.3</version>
 
     <name>Simple ODS library</name>
     <description>A library for load/save ODS files in java.</description>
@@ -71,6 +71,7 @@
             Bundle-SymbolicName: com.github.miachm.sods
             Automatic-Module-Name: com.github.miachm.sods
             -jpms-module-info: com.github.miachm.sods
+            -sources: true
             ]]></bnd>
             </configuration>
             <extensions>true</extensions>

--- a/src/com/github/miachm/sods/SpreadSheet.java
+++ b/src/com/github/miachm/sods/SpreadSheet.java
@@ -195,7 +195,7 @@ public class SpreadSheet implements Cloneable {
      * @throws IOException In case of an io error.
      */
     public void save(OutputStream out) throws IOException {
-        OdsWritter.save(out,this);
+        OdsWriter.save(out,this);
     }
 
     /**


### PR DESCRIPTION
 - Fixed bug with cell values which contain line separators - setting those via both `office:string-value` attribute and `text:p` element results in `office:string-value` taking precedence and text displayed containing no line breaks
 
 - Added BND instruction to include sources in OSGi jar 

 - Fixed spelling mistake in `OdsWriter` naming
 
 - Bumped version to 1.5.3