### PR TITLE
Linked values, line breaks issue and naming fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.github.miachm.sods</groupId>
     <artifactId>SODS</artifactId>
     <packaging>jar</packaging>
-    <version>1.5.2</version>
+    <version>1.5.3</version>
 
     <name>Simple ODS library</name>
     <description>A library for load/save ODS files in java.</description>
@@ -71,6 +71,7 @@
             Bundle-SymbolicName: com.github.miachm.sods
             Automatic-Module-Name: com.github.miachm.sods
             -jpms-module-info: com.github.miachm.sods
+            -sources: true
             ]]></bnd>
             </configuration>
             <extensions>true</extensions>

--- a/src/com/github/miachm/sods/Cell.java
+++ b/src/com/github/miachm/sods/Cell.java
@@ -1,7 +1,7 @@
 package com.github.miachm.sods;
 
 import java.time.LocalDate;
-import java.util.Objects;
+import java.util.*;
 
 class Cell extends TableField {
     private Object value;
@@ -10,8 +10,10 @@ class Cell extends TableField {
     private GroupCell group;
     private OfficeAnnotation annotation;
 
-    Cell()
-    {
+    private List<LinkedValue> linkedValues;
+
+    Cell() {
+        linkedValues = new ArrayList<>();
     }
 
     GroupCell getGroup() {
@@ -56,6 +58,7 @@ class Cell extends TableField {
         formula = null;
         style = Style.default_style;
         annotation = null;
+        linkedValues = new ArrayList<>();
     }
 
     String getFormula() {
@@ -102,6 +105,22 @@ class Cell extends TableField {
         this.annotation = annotation;
     }
 
+    List<LinkedValue> getLinkedValues() {
+        return linkedValues;
+    }
+
+    boolean hasLinkedValues() {
+        return !linkedValues.isEmpty();
+    }
+
+    void setLinkedValues(List<LinkedValue> linkedValues) {
+        this.linkedValues = linkedValues;
+    }
+
+    void addLinkedValue(LinkedValue linkedValue) {
+        this.linkedValues.add(linkedValue);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -124,6 +143,7 @@ class Cell extends TableField {
         if (!Objects.equals(formula, cell.formula)) return false;
         if (!Objects.equals(annotation, cell.annotation)) return false;
         if (!Objects.equals(num_repeated, cell.num_repeated)) return false;
+        if (!Objects.equals(linkedValues, cell.linkedValues)) return false;
         return style.equals(cell.getStyle());
     }
 
@@ -139,6 +159,7 @@ class Cell extends TableField {
         result = 31 * result + style.hashCode();
         result = 31 * result + (group != null ? group.hashCode() : 0);
         result = 31 * result + annotation.hashCode();
+        result = 31 * result + linkedValues.hashCode();
         return result;
     }
 
@@ -147,6 +168,7 @@ class Cell extends TableField {
         if (getGroup() == null || getGroup().getCell() == this)
             return "Cell{" +
                     "value=" + value +
+                    ", linkedValues='" + Arrays.toString(linkedValues.toArray()) + '\'' +
                     ", formula='" + formula + '\'' +
                     ", style=" + style +
                     ", num_repeated=" + num_repeated +

--- a/src/com/github/miachm/sods/LinkedValue.java
+++ b/src/com/github/miachm/sods/LinkedValue.java
@@ -1,0 +1,87 @@
+package com.github.miachm.sods;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URL;
+import java.util.Objects;
+
+/**
+ * Represents a value linked to a sheet, file, URI or URL.
+ */
+public class LinkedValue {
+    private final String href;
+    private final String value;
+
+    LinkedValue(String href, String value) {
+        this.href = href;
+        this.value = value;
+    }
+
+    public static LinkedValue.Builder builder() {
+        return new LinkedValue.Builder();
+    }
+
+    String getHref() {
+        return href;
+    }
+
+    String getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LinkedValue that = (LinkedValue) o;
+        return Objects.equals(href, that.href) && Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(href, value);
+    }
+
+    @Override
+    public String toString() {
+        return "LinkedValue{" +
+                "href='" + href + '\'' +
+                ", value=" + value +
+                '}';
+    }
+
+    public static class Builder {
+        private String href;
+        private String value;
+
+        public LinkedValue build() {
+            return new LinkedValue(href, value);
+        }
+
+        public LinkedValue.Builder value(String value) {
+            this.value = value;
+            return this;
+        }
+
+        public LinkedValue.Builder href(Sheet sheet) {
+            this.href = '#' + sheet.getName() + ".A1";
+            // this.href = '#' + sheet.getName(); // TODO: remove this - not compatible with Excel
+            return this;
+        }
+
+        public LinkedValue.Builder href(File file) {
+            this.href = file.toURI().toString();
+            return this;
+        }
+
+        public LinkedValue.Builder href(URL url) {
+            this.href = url.toString();
+            return this;
+        }
+
+        public LinkedValue.Builder href(URI uri) {
+            this.href = uri.toString();
+            return this;
+        }
+    }
+}

--- a/src/com/github/miachm/sods/OdsWriter.java
+++ b/src/com/github/miachm/sods/OdsWriter.java
@@ -5,6 +5,7 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 import java.io.*;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -18,6 +19,7 @@ class OdsWriter {
     private final static String style_namespace = "urn:oasis:names:tc:opendocument:xmlns:style:1.0";
     private final static String metadata_namespace = "http://purl.org/dc/elements/1.1/";
     private final static String datatype_namespace ="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0";
+    private final static String xlink_namespace ="http://www.w3.org/1999/xlink";
 
     private SpreadSheet spread;
     private Compressor out;
@@ -108,6 +110,7 @@ class OdsWriter {
         out.writeAttribute("xmlns:style", style_namespace);
         out.writeAttribute("xmlns:dc", metadata_namespace);
         out.writeAttribute("xmlns:number", datatype_namespace);
+        out.writeAttribute("xmlns:xlink", xlink_namespace);
 
         out.writeAttribute("office:version", "1.2");
 
@@ -263,43 +266,58 @@ class OdsWriter {
     }
 
     private void writeValue(XMLStreamWriter out, Cell cell) throws XMLStreamException {
-        Object v = cell.getValue();
-        if (v != null) {
-            OfficeValueType valueType = OfficeValueType.ofJavaType(v.getClass());
+        if (!cell.hasLinkedValues()) {
+            Object v = cell.getValue();
+            if (v != null) {
+                OfficeValueType valueType = OfficeValueType.ofJavaType(v.getClass());
 
-            String text = v.toString();
-            if (text.contains(System.lineSeparator())) {
+                String text = v.toString();
+                if (text.contains(System.lineSeparator())) {
+                    valueType.write("", out);
+
+                    out.writeStartElement("text:p");
+
+                    for (int i = 0; i < text.length(); i++) {
+                        if (text.charAt(i) == ' ') {
+                            out.writeStartElement("text:s");
+                            int cnt = 0;
+                            while (i + cnt < text.length() && text.charAt(i + cnt) == ' ') {
+                                cnt++;
+                            }
+                            if (cnt > 1)
+                                out.writeAttribute("text:c", "" + cnt);
+                            i += cnt - 1;
+                            out.writeEndElement();
+                        } else if (text.charAt(i) == '\t') {
+                            out.writeEmptyElement("text:tab");
+                        } else if (text.charAt(i) == '\n') {
+                            out.writeEndElement();
+                            out.writeStartElement("text:p");
+                        } else
+                            out.writeCharacters("" + text.charAt(i));
+                    }
+
+                    out.writeEndElement();
+
+                } else {
+                    valueType.write(v, out);
+                }
+            }
+        } else {
+            List<LinkedValue> links = cell.getLinkedValues();
+            if (links != null && !links.isEmpty()) {
+                OfficeValueType valueType = OfficeValueType.ofJavaType(String.class);
                 valueType.write("", out);
 
-                out.writeStartElement("text:p");
-
-                for (int i = 0; i < text.length(); i++) {
-                    if (text.charAt(i) == ' ') {
-                        out.writeStartElement("text:s");
-                        int cnt = 0;
-                        while (i+cnt < text.length() && text.charAt(i + cnt) == ' ') {
-                            cnt++;
-                        }
-                        if (cnt > 1)
-                            out.writeAttribute("text:c", "" + cnt);
-                        i += cnt - 1 ;
-                        out.writeEndElement();
-                    }
-                    else if (text.charAt(i) == '\t') {
-                        out.writeEmptyElement("text:tab");
-                    }
-                    else if (text.charAt(i) == '\n') {
-                        out.writeEndElement();
-                        out.writeStartElement("text:p");
-                    }
-                    else
-                        out.writeCharacters("" + text.charAt(i));
+                for (LinkedValue link : links) {
+                    out.writeStartElement("text:p");
+                    out.writeStartElement("text:a");
+                    out.writeAttribute("xlink:href", link.getHref());
+                    out.writeAttribute("xlink:type", "simple");
+                    out.writeCharacters(link.getValue());
+                    out.writeEndElement();
+                    out.writeEndElement();
                 }
-
-                out.writeEndElement();
-
-            } else {
-                valueType.write(v, out);
             }
         }
 

--- a/src/com/github/miachm/sods/SpreadSheet.java
+++ b/src/com/github/miachm/sods/SpreadSheet.java
@@ -195,7 +195,7 @@ public class SpreadSheet implements Cloneable {
      * @throws IOException In case of an io error.
      */
     public void save(OutputStream out) throws IOException {
-        OdsWritter.save(out,this);
+        OdsWriter.save(out,this);
     }
 
     /**

--- a/tests/com/github/miachm/sods/RangeTest.java
+++ b/tests/com/github/miachm/sods/RangeTest.java
@@ -3,7 +3,11 @@ package com.github.miachm.sods;
 import org.testng.annotations.Test;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
+import static java.util.Arrays.asList;
 import static org.testng.Assert.fail;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNull;
@@ -930,5 +934,123 @@ public class RangeTest {
         assertEquals(arr[1][0], annotation);
         assertEquals(arr[1][1], null);
         assertEquals(arr[1][2], annotation);
+    }
+
+    @Test
+    public void testAddLinkedValue() throws Exception {
+        Sheet sheet = new Sheet("A");
+        sheet.appendRow();
+        sheet.appendColumn();
+
+        Range range = sheet.getDataRange();
+
+        Sheet linkedSheet = new Sheet("B");
+        LinkedValue linkedValue = LinkedValue.builder().value("linked to").href(linkedSheet).build();
+        range.addLinkedValue(linkedValue);
+
+        List<LinkedValue>[][] arr = range.getLinkedValues();
+
+        assertEquals(arr[0][0].get(0), linkedValue);
+        assertEquals(arr[0][1].get(0), linkedValue);
+        assertEquals(arr[1][0].get(0), linkedValue);
+        assertEquals(arr[1][1].get(0), linkedValue);
+    }
+
+    @Test
+    public void testAddLinkedValues() throws Exception {
+        Sheet sheet = new Sheet("A");
+        sheet.appendRow();
+        sheet.appendColumn();
+
+        Range range = sheet.getDataRange();
+
+        Sheet linkedSheetB = new Sheet("B");
+        LinkedValue linkedValue1 = LinkedValue.builder().value("1 linked to").href(linkedSheetB).build();
+
+        Sheet linkedSheetC = new Sheet("C");
+        LinkedValue linkedValue2 = LinkedValue.builder().value("2 linked to").href(linkedSheetC).build();
+
+        Sheet linkedSheetD = new Sheet("D");
+        LinkedValue linkedValue3 = LinkedValue.builder().value("3 linked to").href(linkedSheetD).build();
+
+        Sheet linkedSheetE = new Sheet("E");
+        LinkedValue linkedValue4 = LinkedValue.builder().value("4 linked to").href(linkedSheetE).build();
+
+        range.addLinkedValues(linkedValue1, linkedValue2, linkedValue3, linkedValue4);
+
+        List<LinkedValue>[][] arr = range.getLinkedValues();
+
+        assertEquals(arr[0][0].get(0), linkedValue1);
+        assertEquals(arr[0][1].get(0), linkedValue2);
+        assertEquals(arr[1][0].get(0), linkedValue3);
+        assertEquals(arr[1][1].get(0), linkedValue4);
+    }
+
+    @Test
+    public void testSetLinkedValues() throws Exception {
+        Sheet sheet = new Sheet("A");
+        sheet.appendRow();
+        sheet.appendColumn();
+
+        Range range = sheet.getDataRange();
+
+        Sheet linkedSheet = new Sheet("B");
+
+        List<LinkedValue> linkedValues = new ArrayList<>(asList(LinkedValue.builder().value("linked to").href(linkedSheet).build()));
+        range.setLinkedValues(linkedValues);
+
+        List<LinkedValue>[][] arr = range.getLinkedValues();
+
+        assertEquals(arr[0][0], linkedValues);
+        assertEquals(arr[0][1], linkedValues);
+        assertEquals(arr[1][0], linkedValues);
+        assertEquals(arr[1][1], linkedValues);
+    }
+
+    @Test
+    public void testSetLinkedValuesMat() throws Exception {
+        Sheet sheet = new Sheet("A");
+        sheet.appendRow();
+        sheet.appendColumns(2);
+
+        Range range = sheet.getDataRange();
+
+        List<LinkedValue>[][] linkedValuesArr = new ArrayList[2][3];
+
+        Sheet linkedSheetB = new Sheet("B");
+        LinkedValue linkedValue1 = LinkedValue.builder().value("1 linked to").href(linkedSheetB).build();
+
+        Sheet linkedSheetC = new Sheet("C");
+        LinkedValue linkedValue2 = LinkedValue.builder().value("2 linked to").href(linkedSheetC).build();
+
+        Sheet linkedSheetD = new Sheet("D");
+        LinkedValue linkedValue3 = LinkedValue.builder().value("3 linked to").href(linkedSheetD).build();
+
+        Sheet linkedSheetE = new Sheet("E");
+        LinkedValue linkedValue4 = LinkedValue.builder().value("4 linked to").href(linkedSheetE).build();
+
+        Sheet linkedSheetF = new Sheet("F");
+        LinkedValue linkedValue5 = LinkedValue.builder().value("5 linked to").href(linkedSheetF).build();
+
+        Sheet linkedSheetG = new Sheet("G");
+        LinkedValue linkedValue6 = LinkedValue.builder().value("6 linked to").href(linkedSheetG).build();
+
+        linkedValuesArr[0][0] = new ArrayList<>(asList(linkedValue1));
+        linkedValuesArr[0][1] = new ArrayList<>(asList(linkedValue2));
+        linkedValuesArr[0][2] = new ArrayList<>(asList(linkedValue3));
+        linkedValuesArr[1][0] = new ArrayList<>(asList(linkedValue4));
+        linkedValuesArr[1][1] = new ArrayList<>(asList(linkedValue5));
+        linkedValuesArr[1][2] = new ArrayList<>(asList(linkedValue6));
+
+        range.setLinkedValues(linkedValuesArr);
+
+        List<LinkedValue>[][] arr = range.getLinkedValues();
+
+        assertEquals(arr[0][0].get(0), linkedValue1);
+        assertEquals(arr[0][1].get(0), linkedValue2);
+        assertEquals(arr[0][2].get(0), linkedValue3);
+        assertEquals(arr[1][0].get(0), linkedValue4);
+        assertEquals(arr[1][1].get(0), linkedValue5);
+        assertEquals(arr[1][2].get(0), linkedValue6);
     }
 }


### PR DESCRIPTION
 - Added support for linked values, i.e. linking cell value to a sheet, file, URI or URL
 
 - Fixed bug with cell values which contain line separators - setting those via both `office:string-value` attribute and `text:p` element results in `office:string-value` taking precedence and text displayed containing no line breaks
 
 - Added BND instruction to include sources in OSGi jar 

 - Fixed spelling mistake in `OdsWriter` naming
 
 - Bumped version to 1.5.3
