### PR TITLE
Correctly handle emojis and other non-BMP characters.

### DIFF
--- a/src/com/github/miachm/sods/OdsWritter.java
+++ b/src/com/github/miachm/sods/OdsWritter.java
@@ -290,6 +290,11 @@ class OdsWritter {
                     out.writeEndElement();
                     out.writeStartElement("text:p");
                 }
+                else if (Character.isHighSurrogate(text.charAt(i)) && i + 1 < text.length() && Character.isLowSurrogate(text.charAt(i + 1))) {
+                    // write surrogate pair
+                    out.writeCharacters("" + text.charAt(i) + text.charAt(i + 1));
+                    i++;
+                }
                 else
                     out.writeCharacters("" + text.charAt(i));
             }
@@ -529,7 +534,7 @@ class OdsWritter {
     }
     
     private void writeBorderStyle(XMLStreamWriter out, Style style) throws XMLStreamException {
-    	
+
 		Borders borders = style.getBorders();
 		if (borders.isBorder()) {
 			out.writeAttribute("fo:border", borders.getBorderProperties());

--- a/tests/com/github/miachm/sods/ValueTypeTest.java
+++ b/tests/com/github/miachm/sods/ValueTypeTest.java
@@ -58,6 +58,20 @@ public class ValueTypeTest {
     }
 
     @Test
+    public void testUnicodeCharacters()
+    {
+        // Text not in the Basic Multilingual Plane (BMP) is encoded using a surrogate pair
+        // https://docs.oracle.com/javase/specs/jls/se7/html/jls-3.html#jls-3.1
+        String text = "\uD83D\uDE00"; // 😀
+
+        Sheet sheet = new Sheet("A", 1, 1);
+        sheet.getDataRange().setValues(text);
+        sheet = saveAndLoad(sheet);
+
+        assertEquals(sheet.getRange(0, 0).getValue(), text);
+    }
+
+    @Test
     public void testCurrency()
     {
         OfficeCurrency canada = new OfficeCurrency(Currency.getInstance(Locale.CANADA), 30.0);


### PR DESCRIPTION
This commit improves support for non-BMP Unicode characters in Java by correctly handling their encoding in surrogate pairs.