### PR TITLE
Add LinkedValue (cell hyperlink) support - Porting #63 to the current codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,18 +14,18 @@ A simple Java library for reading and writing ODS (OpenDocument Spreadsheet) fil
 <dependency>
     <groupId>com.github.miachm.sods</groupId>
     <artifactId>SODS</artifactId>
-    <version>1.9.0</version>
+    <version>1.10.0</version>
 </dependency>
 ```
 ### Gradle Kotlin DSL
 ```kotlin
-implementation("com.github.miachm.sods:SODS:1.9.0")
+implementation("com.github.miachm.sods:SODS:1.10.0")
 ```
 ### Gradle Groovy DSL
 ```groovy
-implementation 'com.github.miachm.sods:SODS:1.9.0'
+implementation 'com.github.miachm.sods:SODS:1.10.0'
 ```
-### [Other Dependency Management](https://search.maven.org/artifact/com.github.miachm.sods/SODS/1.9.0/jar)
+### [Other Dependency Management](https://search.maven.org/artifact/com.github.miachm.sods/SODS/1.10.0/jar)
 
 ## Docs
 You can access the javadocs [here](https://miachm.github.io/SODS/)

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.github.miachm.sods</groupId>
   <artifactId>SODS</artifactId>
-  <version>1.9.0</version>
+  <version>1.10.0</version>
   <packaging>jar</packaging>
 
   <name>Simple ODS library</name>

--- a/src/com/github/miachm/sods/Cell.java
+++ b/src/com/github/miachm/sods/Cell.java
@@ -1,6 +1,9 @@
 package com.github.miachm.sods;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 class Cell extends TableField {
@@ -9,9 +12,11 @@ class Cell extends TableField {
     private Style style = Style.default_style;
     private GroupCell group;
     private OfficeAnnotation annotation;
+    private List<LinkedValue> linkedValues;
 
     Cell()
     {
+        linkedValues = new ArrayList<>();
     }
 
     GroupCell getGroup() {
@@ -60,6 +65,7 @@ class Cell extends TableField {
         formula = null;
         style = Style.default_style;
         annotation = null;
+        linkedValues = new ArrayList<>();
     }
 
     String getFormula() {
@@ -112,6 +118,22 @@ class Cell extends TableField {
         this.annotation = annotation;
     }
 
+    List<LinkedValue> getLinkedValues() {
+        return linkedValues;
+    }
+
+    boolean hasLinkedValues() {
+        return !linkedValues.isEmpty();
+    }
+
+    void setLinkedValues(List<LinkedValue> linkedValues) {
+        this.linkedValues = linkedValues;
+    }
+
+    void addLinkedValue(LinkedValue linkedValue) {
+        this.linkedValues.add(linkedValue);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -134,6 +156,7 @@ class Cell extends TableField {
         if (!Objects.equals(formula, cell.formula)) return false;
         if (!Objects.equals(annotation, cell.annotation)) return false;
         if (!Objects.equals(num_repeated, cell.num_repeated)) return false;
+        if (!Objects.equals(linkedValues, cell.linkedValues)) return false;
         return style.equals(cell.getStyle());
     }
 
@@ -149,6 +172,7 @@ class Cell extends TableField {
         result = 31 * result + style.hashCode();
         result = 31 * result + (group != null ? group.hashCode() : 0);
         result = 31 * result + annotation.hashCode();
+        result = 31 * result + linkedValues.hashCode();
         return result;
     }
 
@@ -157,6 +181,7 @@ class Cell extends TableField {
         if (getGroup() == null || getGroup().getCell() == this)
             return "Cell{" +
                     "value=" + value +
+                    ", linkedValues='" + Arrays.toString(linkedValues.toArray()) + '\'' +
                     ", formula='" + formula + '\'' +
                     ", style=" + style +
                     ", num_repeated=" + num_repeated +

--- a/src/com/github/miachm/sods/LinkedValue.java
+++ b/src/com/github/miachm/sods/LinkedValue.java
@@ -1,0 +1,88 @@
+package com.github.miachm.sods;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URL;
+import java.util.Objects;
+
+/**
+ * Represents a value linked to a sheet, file, URI or URL.
+ */
+public class LinkedValue {
+    private final String href;
+    private final String text;
+
+    private LinkedValue(String href, String text) {
+        this.href = href;
+        this.text = text;
+    }
+
+    /**
+     * Creates a value linking to a cell of the given sheet.
+     *
+     * @param text  the text to display for the link
+     * @param sheet the sheet to link to
+     */
+    public LinkedValue(String text, Sheet sheet) {
+        this('#' + sheet.getName() + ".A1", text);
+    }
+
+    /**
+     * Creates a value linking to the given file.
+     *
+     * @param text the text to display for the link
+     * @param file the file to link to
+     */
+    public LinkedValue(String text, File file) {
+        this(file.toURI().toString(), text);
+    }
+
+    /**
+     * Creates a value linking to the given URL.
+     *
+     * @param text the text to display for the link
+     * @param url  the URL to link to
+     */
+    public LinkedValue(String text, URL url) {
+        this(url.toString(), text);
+    }
+
+    /**
+     * Creates a value linking to the given URI.
+     *
+     * @param text the text to display for the link
+     * @param uri  the URI to link to
+     */
+    public LinkedValue(String text, URI uri) {
+        this(uri.toString(), text);
+    }
+
+    String getHref() {
+        return href;
+    }
+
+    String getText() {
+        return text;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LinkedValue that = (LinkedValue) o;
+        return Objects.equals(href, that.href) && Objects.equals(text, that.text);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(href, text);
+    }
+
+    @Override
+    public String toString() {
+        return "LinkedValue{" +
+                "href='" + href + '\'' +
+                ", text=" + text +
+                '}';
+    }
+}

--- a/src/com/github/miachm/sods/Range.java
+++ b/src/com/github/miachm/sods/Range.java
@@ -1,6 +1,7 @@
 package com.github.miachm.sods;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -786,6 +787,7 @@ public class Range {
                 "\nnumrows=" + numrows +
                 "\nnumcolumns=" + numcolumns +
                 "\nvalues =\n\n" + (getNumValues() < MAX_PRINTABLE ? valuesToString() : "too long for print") +
+                "\nlinkedValues =\n\n" + (getNumValues() < MAX_PRINTABLE ? linkedValuesToString() : "too long for print") +
                 "\n}";
     }
 
@@ -957,5 +959,108 @@ public class Range {
      */
     public void forEach(LogicalCellConsumer consumer) {
         new CellIterator(sheet, row_init, column_init, row_init + numrows, column_init + numcolumns).foreachRemaining(consumer);
+    }
+
+    /**
+     * Add a linked value for all the cells in this range.
+     *
+     * @param linkedValue The linked value to be added
+     *
+     * @see LinkedValue
+     */
+    public void addLinkedValue(LinkedValue linkedValue) {
+        iterateRangeUniform((cell, row, column) -> cell.addLinkedValue(linkedValue));
+    }
+
+    /**
+     * Add a set of linked values to the range. The array must have the same size of the entire range itself.
+     *
+     * @param linkedValues The linked values array, it must the same size of the range itself.
+     * @throws IllegalArgumentException if the number of linked values is not equals to the size of range
+     */
+    public void addLinkedValues(LinkedValue... linkedValues) {
+        if (linkedValues.length != getNumValues()) {
+            throw new IllegalArgumentException("Error in addLinkedValues, the number of the arguments doesn't fit ("
+                    + linkedValues.length + " against " + getNumValues() + ")");
+        }
+
+        iterateRangeEachLogicalCell((cell, row, column) -> cell.addLinkedValue(linkedValues[row * getNumColumns() + column]));
+    }
+
+    /**
+     * Set linked values for all the cells in this range.
+     *
+     * @param linkedValues The linkedValues to be set in the range
+     *
+     * @see LinkedValue
+     */
+    public void setLinkedValues(List<LinkedValue> linkedValues) {
+        iterateRangeUniform((cell, row, column) -> cell.setLinkedValues(linkedValues));
+    }
+
+    /**
+     * Set a set of linked values to the range. The array must have the same size of the entire range itself.
+     *
+     * @param linkedValues The linkedValues array, it must the same size of the range itself.
+     * @throws IllegalArgumentException if the number of linked values is not equals to the size of range
+     */
+    public void setLinkedValues(List<LinkedValue>... linkedValues) {
+        if (linkedValues.length != getNumValues()) {
+            throw new IllegalArgumentException("Error in setLinkedValues, the number of the arguments doesn't fit ("
+                    + linkedValues.length + " against " + getNumValues() + ")");
+        }
+
+        iterateRangeEachLogicalCell((cell, row, column) -> cell.setLinkedValues(linkedValues[row * getNumColumns() + column]));
+    }
+
+    /**
+     * Sets a set of linked values to the range. The array must have the same size of the entire range itself.
+     *
+     * @param linkedValues The linkedValues 2D-array, it must have the same size of the range itself
+     * @throws IllegalArgumentException if the number of linked values is not equals to the size of range
+     */
+    public void setLinkedValues(List<LinkedValue>[][] linkedValues) {
+        if (linkedValues.length == 0) {
+            throw new IllegalArgumentException("Error in setLinkedValues, the array is empty");
+        }
+        if (linkedValues.length != getNumRows()) {
+            throw new IllegalArgumentException("Error in setLinkedValues, the number of rows doesn't fit ("
+                    + linkedValues.length + " against " + getNumRows() + ")");
+        }
+        if (linkedValues[0].length != getNumColumns()) {
+            throw new IllegalArgumentException("Error in setLinkedValues, the number of columns doesn't fit ("
+                    + linkedValues[0].length + " against " + getNumColumns() + ")");
+        }
+
+        iterateRangeEachLogicalCell((cell, row, column) -> cell.setLinkedValues(linkedValues[row][column]));
+    }
+
+    /**
+     * Returns the rectangular grid of linked values for this range.
+     *
+     * @see LinkedValue
+     * @return A two-dimensional array of linked values.
+     */
+    public List<LinkedValue>[][] getLinkedValues() {
+        List<LinkedValue>[][] linkedValues = new ArrayList[getNumRows()][getNumColumns()];
+        iterateRangeReadOnly((cell, row, column) -> linkedValues[row][column] = cell.getLinkedValues());
+        return linkedValues;
+    }
+
+    private String linkedValuesToString() {
+        StringBuilder builder = new StringBuilder();
+
+        MutableInteger lastRow = new MutableInteger();
+        iterateRangeReadOnly((cell, i, j) -> {
+            if (lastRow.number != i) {
+                builder.append("\n");
+                lastRow.number = i;
+            }
+            if (j > 0) {
+                builder.append(" , ");
+            }
+            builder.append(Arrays.toString(cell.getLinkedValues().toArray()));
+        });
+        return builder.toString();
     }
 }

--- a/src/com/github/miachm/sods/SheetWriter.java
+++ b/src/com/github/miachm/sods/SheetWriter.java
@@ -218,52 +218,70 @@ class SheetWriter {
     }
 
     private void writeValue(XMLStreamWriter out, Cell cell) throws XMLStreamException {
-        Object v = cell.getValue();
-        if (v != null) {
-            OfficeValueType valueType = OfficeValueType.ofJavaType(v.getClass());
-            /*
-                This fixes issue #65.
-                LibreOffice only writes the "string-value" attribute for formulaic cells. Writing it for non-formulaic
-                cells makes LibreOffice discard newlines when opening the sheet.
-             */
-            if (valueType != OfficeValueType.STRING || cell.getFormula() != null) {
-                valueType.write(v, out);
-            }
-            else if (valueType == OfficeValueType.STRING) {
-                out.writeAttribute(OFFICE, "value-type", "string");
-            }
+        if (!cell.hasLinkedValues()) {
+            Object v = cell.getValue();
+            if (v != null) {
+                OfficeValueType valueType = OfficeValueType.ofJavaType(v.getClass());
+                /*
+                    This fixes issue #65.
+                    LibreOffice only writes the "string-value" attribute for formulaic cells. Writing it for non-formulaic
+                    cells makes LibreOffice discard newlines when opening the sheet.
+                 */
+                if (valueType != OfficeValueType.STRING || cell.getFormula() != null) {
+                    valueType.write(v, out);
+                }
+                else if (valueType == OfficeValueType.STRING) {
+                    out.writeAttribute(OFFICE, "value-type", "string");
+                }
 
-            out.writeStartElement(TEXT, "p");
-            String text = v.toString();
+                out.writeStartElement(TEXT, "p");
+                String text = v.toString();
 
-            for (int i = 0; i < text.length(); i++) {
-                if (text.charAt(i) == ' ') {
-                    out.writeStartElement(TEXT, "s");
-                    int cnt = 0;
-                    while (i+cnt < text.length() && text.charAt(i + cnt) == ' ') {
-                        cnt++;
+                for (int i = 0; i < text.length(); i++) {
+                    if (text.charAt(i) == ' ') {
+                        out.writeStartElement(TEXT, "s");
+                        int cnt = 0;
+                        while (i+cnt < text.length() && text.charAt(i + cnt) == ' ') {
+                            cnt++;
+                        }
+                        if (cnt > 1)
+                            out.writeAttribute(TEXT, "c", "" + cnt);
+                        i += cnt - 1 ;
+                        out.writeEndElement();
                     }
-                    if (cnt > 1)
-                        out.writeAttribute(TEXT, "c", "" + cnt);
-                    i += cnt - 1 ;
+                    else if (text.charAt(i) == '\t') {
+                        out.writeEmptyElement(TEXT, "tab");
+                    }
+                    else if (text.charAt(i) == '\n') {
+                        out.writeEmptyElement(TEXT, "line-break");
+                    }
+                    else if (Character.isHighSurrogate(text.charAt(i)) && i + 1 < text.length() && Character.isLowSurrogate(text.charAt(i + 1))) {
+                        // write surrogate pair
+                        out.writeCharacters("" + text.charAt(i) + text.charAt(i + 1));
+                        i++;
+                    }
+                    else
+                        out.writeCharacters("" + text.charAt(i));
+                }
+
+                out.writeEndElement();
+            }
+        }
+        else {
+            List<LinkedValue> links = cell.getLinkedValues();
+            if (links != null && !links.isEmpty()) {
+                OfficeValueType.ofJavaType(String.class).write("", out);
+
+                for (LinkedValue link : links) {
+                    out.writeStartElement(TEXT, "p");
+                    out.writeStartElement(TEXT, "a");
+                    out.writeAttribute(XLINK, "href", link.getHref());
+                    out.writeAttribute(XLINK, "type", "simple");
+                    out.writeCharacters(link.getText());
+                    out.writeEndElement();
                     out.writeEndElement();
                 }
-                else if (text.charAt(i) == '\t') {
-                    out.writeEmptyElement(TEXT, "tab");
-                }
-                else if (text.charAt(i) == '\n') {
-                    out.writeEmptyElement(TEXT, "line-break");
-                }
-                else if (Character.isHighSurrogate(text.charAt(i)) && i + 1 < text.length() && Character.isLowSurrogate(text.charAt(i + 1))) {
-                    // write surrogate pair
-                    out.writeCharacters("" + text.charAt(i) + text.charAt(i + 1));
-                    i++;
-                }
-                else
-                    out.writeCharacters("" + text.charAt(i));
             }
-
-            out.writeEndElement();
         }
         OfficeAnnotation annotation = cell.getAnnotation();
         if (annotation != null) {

--- a/tests/com/github/miachm/sods/RangeTest.java
+++ b/tests/com/github/miachm/sods/RangeTest.java
@@ -1,13 +1,15 @@
 package com.github.miachm.sods;
 
-import org.testng.annotations.Test;
-
-import java.time.LocalDateTime;
-
+import static java.util.Arrays.asList;
 import static org.testng.Assert.fail;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNull;
-import static org.testng.AssertJUnit.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.testng.annotations.Test;
 
 public class RangeTest {
     @Test
@@ -1047,5 +1049,123 @@ public class RangeTest {
         assertEquals(values[2][1], 7);
         assertEquals(values[2][2], 7);
         assertEquals(values[2][3], 7);
+    }
+
+    @Test
+    public void testAddLinkedValue() throws Exception {
+        Sheet sheet = new Sheet("A");
+        sheet.appendRow();
+        sheet.appendColumn();
+
+        Range range = sheet.getDataRange();
+
+        Sheet linkedSheet = new Sheet("B");
+        LinkedValue linkedValue = new LinkedValue("linked to", linkedSheet);
+        range.addLinkedValue(linkedValue);
+
+        List<LinkedValue>[][] arr = range.getLinkedValues();
+
+        assertEquals(arr[0][0].get(0), linkedValue);
+        assertEquals(arr[0][1].get(0), linkedValue);
+        assertEquals(arr[1][0].get(0), linkedValue);
+        assertEquals(arr[1][1].get(0), linkedValue);
+    }
+
+    @Test
+    public void testAddLinkedValues() throws Exception {
+        Sheet sheet = new Sheet("A");
+        sheet.appendRow();
+        sheet.appendColumn();
+
+        Range range = sheet.getDataRange();
+
+        Sheet linkedSheetB = new Sheet("B");
+        LinkedValue linkedValue1 = new LinkedValue("1 linked to", linkedSheetB);
+
+        Sheet linkedSheetC = new Sheet("C");
+        LinkedValue linkedValue2 = new LinkedValue("2 linked to", linkedSheetC);
+
+        Sheet linkedSheetD = new Sheet("D");
+        LinkedValue linkedValue3 = new LinkedValue("3 linked to", linkedSheetD);
+
+        Sheet linkedSheetE = new Sheet("E");
+        LinkedValue linkedValue4 = new LinkedValue("4 linked to", linkedSheetE);
+
+        range.addLinkedValues(linkedValue1, linkedValue2, linkedValue3, linkedValue4);
+
+        List<LinkedValue>[][] arr = range.getLinkedValues();
+
+        assertEquals(arr[0][0].get(0), linkedValue1);
+        assertEquals(arr[0][1].get(0), linkedValue2);
+        assertEquals(arr[1][0].get(0), linkedValue3);
+        assertEquals(arr[1][1].get(0), linkedValue4);
+    }
+
+    @Test
+    public void testSetLinkedValues() throws Exception {
+        Sheet sheet = new Sheet("A");
+        sheet.appendRow();
+        sheet.appendColumn();
+
+        Range range = sheet.getDataRange();
+
+        Sheet linkedSheet = new Sheet("B");
+
+        List<LinkedValue> linkedValues = new ArrayList<>(asList(new LinkedValue("linked to", linkedSheet)));
+        range.setLinkedValues(linkedValues);
+
+        List<LinkedValue>[][] arr = range.getLinkedValues();
+
+        assertEquals(arr[0][0], linkedValues);
+        assertEquals(arr[0][1], linkedValues);
+        assertEquals(arr[1][0], linkedValues);
+        assertEquals(arr[1][1], linkedValues);
+    }
+
+    @Test
+    public void testSetLinkedValuesMat() throws Exception {
+        Sheet sheet = new Sheet("A");
+        sheet.appendRow();
+        sheet.appendColumns(2);
+
+        Range range = sheet.getDataRange();
+
+        List<LinkedValue>[][] linkedValuesArr = new ArrayList[2][3];
+
+        Sheet linkedSheetB = new Sheet("B");
+        LinkedValue linkedValue1 = new LinkedValue("1 linked to", linkedSheetB);
+
+        Sheet linkedSheetC = new Sheet("C");
+        LinkedValue linkedValue2 = new LinkedValue("2 linked to", linkedSheetC);
+
+        Sheet linkedSheetD = new Sheet("D");
+        LinkedValue linkedValue3 = new LinkedValue("3 linked to", linkedSheetD);
+
+        Sheet linkedSheetE = new Sheet("E");
+        LinkedValue linkedValue4 = new LinkedValue("4 linked to", linkedSheetE);
+
+        Sheet linkedSheetF = new Sheet("F");
+        LinkedValue linkedValue5 = new LinkedValue("5 linked to", linkedSheetF);
+
+        Sheet linkedSheetG = new Sheet("G");
+        LinkedValue linkedValue6 = new LinkedValue("6 linked to", linkedSheetG);
+
+        linkedValuesArr[0][0] = new ArrayList<>(asList(linkedValue1));
+        linkedValuesArr[0][1] = new ArrayList<>(asList(linkedValue2));
+        linkedValuesArr[0][2] = new ArrayList<>(asList(linkedValue3));
+        linkedValuesArr[1][0] = new ArrayList<>(asList(linkedValue4));
+        linkedValuesArr[1][1] = new ArrayList<>(asList(linkedValue5));
+        linkedValuesArr[1][2] = new ArrayList<>(asList(linkedValue6));
+
+        range.setLinkedValues(linkedValuesArr);
+
+        List<LinkedValue>[][] arr = range.getLinkedValues();
+
+        assertEquals(arr[0][0].get(0), linkedValue1);
+        assertEquals(arr[0][1].get(0), linkedValue2);
+        assertEquals(arr[0][2].get(0), linkedValue3);
+        assertEquals(arr[1][0].get(0), linkedValue4);
+        assertEquals(arr[1][1].get(0), linkedValue5);
+        assertEquals(arr[1][2].get(0), linkedValue6);
     }
 }


### PR DESCRIPTION
# Add LinkedValue (cell hyperlink) support
 
Ports cell-level hyperlink support (originally proposed in #63) onto the current codebase.

##  What's added 
  - New LinkedValue type holding a link href (to a Sheet, File, URL, or URI) plus the display text rendered in the cell.
  - Cell and Range accessors to attach/read linked values (addLinkedValue, addLinkedValues, setLinkedValues overloads, getLinkedValues).
  - SheetWriter now emits <text:a xlink:href="…" xlink:type="simple">…</text:a> for cells that carry linked values, leaving the existing value/annotation/newline handling (issue
  #65) untouched.

 ## Review feedback addressed
  - Builder pattern removed — LinkedValue now uses direct overloaded constructors (new LinkedValue("text", target)), consistent with the rest of the SODS API.
  - value → text — the display-text field was renamed to avoid confusion with the cell's own value; it's the visible anchor text of the link, distinct from the href target.
  
 ## Other
  - Version bumped to 1.10.0 (backward-compatible feature addition).
  - Tests added in RangeTest covering single/multi linked values and the matrix setter.
