### PR TITLE
Add DataStylePattern to support more date/time and number formats

### DIFF
--- a/src/com/github/miachm/sods/DataStylePattern.java
+++ b/src/com/github/miachm/sods/DataStylePattern.java
@@ -129,18 +129,25 @@ import java.util.List;
  */
 final class DataStylePattern {
 
+    // Which ODF style family a whole pattern becomes, e.g. "yyyy-MM-dd" ->
+    // DATE_TIME, "0.00" -> NUMBER, "@" -> TEXT.
     enum Kind { TEXT, DATE_TIME, NUMBER }
 
+    // What one letter run in a date/time pattern means, e.g. 'y' -> YEAR,
+    // 's' -> SECOND. TEXT is literal/separator text, not a letter run.
     enum FieldType {
         YEAR, MONTH, DAY, ERA, DAY_OF_WEEK, WEEK_OF_YEAR, QUARTER,
         HOUR24, HOUR12, MINUTE, SECOND, FRACTION_SECOND, AMPM, TEXT
     }
 
+    // One tokenized run from a date/time pattern. "yyyy-MM-dd" tokenizes to
+    // [Field(YEAR,4), Field(TEXT,"-"), Field(MONTH,2), Field(TEXT,"-"),
+    // Field(DAY,2)].
     static final class Field {
-        final FieldType type;
-        final int length;
-        final int decimalPlaces;
-        final String text;
+        final FieldType type;      // e.g. YEAR
+        final int length;          // repeat count, e.g. "yyyy" -> 4
+        final int decimalPlaces;   // SECOND only: "ss.SSS" -> 3
+        final String text;         // TEXT only: the literal characters
 
         private Field(
                 FieldType type, int length, int decimalPlaces, String text) {
@@ -163,15 +170,18 @@ final class DataStylePattern {
         }
     }
 
+    // The whole parsed shape of a numeric pattern, e.g. "$#,##0.00%" ->
+    // prefix="$", minIntegerDigits=1, decimalPlaces=2, grouping=true,
+    // percentage=true.
     static final class NumberSpec {
-        final String prefix;
-        final String suffix;
-        final int minIntegerDigits;
-        final int decimalPlaces;
-        final boolean grouping;
-        final boolean percentage;
-        final boolean scientific;
-        final int minExponentDigits;
+        final String prefix;           // e.g. "$#,##0.00" -> "$"
+        final String suffix;           // e.g. "0.00 kg" -> " kg"
+        final int minIntegerDigits;    // count of leading '0's
+        final int decimalPlaces;       // count of '0'/'#' after '.'
+        final boolean grouping;        // ',' present
+        final boolean percentage;      // '%' present
+        final boolean scientific;      // 'E' present
+        final int minExponentDigits;   // count of '0's after 'E'
 
         NumberSpec(
                 String prefix,

--- a/src/com/github/miachm/sods/DataStylePattern.java
+++ b/src/com/github/miachm/sods/DataStylePattern.java
@@ -135,38 +135,41 @@ final class DataStylePattern {
 
     // What one letter run in a date/time pattern means, e.g. 'y' -> YEAR,
     // 's' -> SECOND. TEXT is literal/separator text, not a letter run.
-    enum FieldType {
+    enum DateTimeFieldType {
         YEAR, MONTH, DAY, ERA, DAY_OF_WEEK, WEEK_OF_YEAR, QUARTER,
         HOUR24, HOUR12, MINUTE, SECOND, FRACTION_SECOND, AMPM, TEXT
     }
 
-    // One tokenized run from a date/time pattern. "yyyy-MM-dd" tokenizes to
-    // [Field(YEAR,4), Field(TEXT,"-"), Field(MONTH,2), Field(TEXT,"-"),
-    // Field(DAY,2)].
-    static final class Field {
-        final FieldType type;      // e.g. YEAR
-        final int length;          // repeat count, e.g. "yyyy" -> 4
-        final int decimalPlaces;   // SECOND only: "ss.SSS" -> 3
-        final String text;         // TEXT only: the literal characters
+    // One tokenized run from a date/time pattern. "yyyy-MM-dd" tokenizes
+    // to [DateTimeField(YEAR,4), DateTimeField(TEXT,"-"),
+    // DateTimeField(MONTH,2), DateTimeField(TEXT,"-"),
+    // DateTimeField(DAY,2)].
+    static final class DateTimeField {
+        final DateTimeFieldType type;  // e.g. YEAR
+        final int length;              // repeat count, e.g. "yyyy" -> 4
+        final int decimalPlaces;       // SECOND only: "ss.SSS" -> 3
+        final String text;             // TEXT only: the literal characters
 
-        private Field(
-                FieldType type, int length, int decimalPlaces, String text) {
+        private DateTimeField(
+                DateTimeFieldType type, int length, int decimalPlaces,
+                String text) {
             this.type = type;
             this.length = length;
             this.decimalPlaces = decimalPlaces;
             this.text = text;
         }
 
-        static Field of(FieldType type, int length) {
-            return new Field(type, length, 0, null);
+        static DateTimeField of(DateTimeFieldType type, int length) {
+            return new DateTimeField(type, length, 0, null);
         }
 
-        static Field ofSecond(int length, int decimalPlaces) {
-            return new Field(FieldType.SECOND, length, decimalPlaces, null);
+        static DateTimeField ofSecond(int length, int decimalPlaces) {
+            return new DateTimeField(
+                    DateTimeFieldType.SECOND, length, decimalPlaces, null);
         }
 
-        static Field ofText(String text) {
-            return new Field(FieldType.TEXT, 0, 0, text);
+        static DateTimeField ofText(String text) {
+            return new DateTimeField(DateTimeFieldType.TEXT, 0, 0, text);
         }
     }
 
@@ -176,7 +179,7 @@ final class DataStylePattern {
     static final class NumberSpec {
         final String prefix;           // e.g. "$#,##0.00" -> "$"
         final String suffix;           // e.g. "0.00 kg" -> " kg"
-        final int minIntegerDigits;    // count of leading '0's
+        final int minIntegerDigits;    // count of '0's in the integer part
         final int decimalPlaces;       // count of '0'/'#' after '.'
         final boolean grouping;        // ',' present
         final boolean percentage;      // '%' present
@@ -217,11 +220,12 @@ final class DataStylePattern {
     static final String ALLOWED_BARE_LITERALS = " -:/.,T";
 
     final Kind kind;
-    final List<Field> dateTimeFields;
+    final List<DateTimeField> dateTimeFields;
     final NumberSpec numberSpec;
 
     private DataStylePattern(
-            Kind kind, List<Field> dateTimeFields, NumberSpec numberSpec) {
+            Kind kind, List<DateTimeField> dateTimeFields,
+            NumberSpec numberSpec) {
         this.kind = kind;
         this.dateTimeFields = dateTimeFields;
         this.numberSpec = numberSpec;
@@ -229,7 +233,7 @@ final class DataStylePattern {
 
     boolean hasDateFields() {
         if (dateTimeFields == null) return false;
-        for (Field field : dateTimeFields) {
+        for (DateTimeField field : dateTimeFields) {
             switch (field.type) {
                 case YEAR: case MONTH: case DAY:
                 case ERA: case DAY_OF_WEEK: case WEEK_OF_YEAR: case QUARTER:
@@ -361,31 +365,31 @@ final class DataStylePattern {
         return new Flat(text.toString(), literal);
     }
 
-    private static FieldType letterFieldType(char c) {
+    private static DateTimeFieldType letterFieldType(char c) {
         // Case-sensitive, matching DateTimeFormatter's own letters. See
         // class Javadoc for why Y/D/A are excluded, why Q/q are aliased,
         // and why only uppercase E is supported.
         switch (c) {
-            case 'y': return FieldType.YEAR;
-            case 'M': return FieldType.MONTH;
-            case 'd': return FieldType.DAY;
-            case 'G': return FieldType.ERA;
-            case 'E': return FieldType.DAY_OF_WEEK;
-            case 'w': return FieldType.WEEK_OF_YEAR;
-            case 'Q': case 'q': return FieldType.QUARTER;
-            case 'H': return FieldType.HOUR24;
-            case 'h': return FieldType.HOUR12;
-            case 'm': return FieldType.MINUTE;
-            case 's': return FieldType.SECOND;
-            case 'S': return FieldType.FRACTION_SECOND;
-            case 'a': return FieldType.AMPM;
+            case 'y': return DateTimeFieldType.YEAR;
+            case 'M': return DateTimeFieldType.MONTH;
+            case 'd': return DateTimeFieldType.DAY;
+            case 'G': return DateTimeFieldType.ERA;
+            case 'E': return DateTimeFieldType.DAY_OF_WEEK;
+            case 'w': return DateTimeFieldType.WEEK_OF_YEAR;
+            case 'Q': case 'q': return DateTimeFieldType.QUARTER;
+            case 'H': return DateTimeFieldType.HOUR24;
+            case 'h': return DateTimeFieldType.HOUR12;
+            case 'm': return DateTimeFieldType.MINUTE;
+            case 's': return DateTimeFieldType.SECOND;
+            case 'S': return DateTimeFieldType.FRACTION_SECOND;
+            case 'a': return DateTimeFieldType.AMPM;
             default: return null;
         }
     }
 
-    private static List<Field> parseDateTime(
+    private static List<DateTimeField> parseDateTime(
             Flat flat, String originalPattern) {
-        List<Field> fields = new ArrayList<>();
+        List<DateTimeField> fields = new ArrayList<>();
         String text = flat.text;
         int n = text.length();
         int i = 0;
@@ -397,26 +401,26 @@ final class DataStylePattern {
                     literalText.append(text.charAt(j));
                     j++;
                 }
-                fields.add(Field.ofText(literalText.toString()));
+                fields.add(DateTimeField.ofText(literalText.toString()));
                 i = j;
                 continue;
             }
 
             char c = text.charAt(i);
-            FieldType type = letterFieldType(c);
+            DateTimeFieldType type = letterFieldType(c);
             if (type != null) {
                 int j = i;
                 while (j < n && !flat.literal[j]
                         && letterFieldType(text.charAt(j)) == type) {
                     j++;
                 }
-                fields.add(Field.of(type, j - i));
+                fields.add(DateTimeField.of(type, j - i));
                 i = j;
                 continue;
             }
 
             if (ALLOWED_BARE_LITERALS.indexOf(c) >= 0) {
-                fields.add(Field.ofText(String.valueOf(c)));
+                fields.add(DateTimeField.ofText(String.valueOf(c)));
                 i++;
                 continue;
             }
@@ -435,12 +439,12 @@ final class DataStylePattern {
     }
 
     private static void validateNoStandaloneFractionSeconds(
-            List<Field> fields, String originalPattern) {
+            List<DateTimeField> fields, String originalPattern) {
         // mergeSecondsFraction folds a valid "s.S" run into one SECOND
         // field. Anything left over here wasn't preceded by a
         // whole-seconds field, which ODF has no way to render.
-        for (Field field : fields) {
-            if (field.type == FieldType.FRACTION_SECOND) {
+        for (DateTimeField field : fields) {
+            if (field.type == DateTimeFieldType.FRACTION_SECOND) {
                 throw new IllegalArgumentException(
                         "Data style pattern uses 'S' (fractional-second "
                                 + "digits) without an immediately "
@@ -454,17 +458,17 @@ final class DataStylePattern {
     }
 
     private static void validateHourAmPmConsistency(
-            List<Field> fields, String originalPattern) {
+            List<DateTimeField> fields, String originalPattern) {
         // ODF's number:hours has no 12h/24h attribute -- a sibling
         // number:am-pm element is what decides it. Enforce the pairing
         // 'h'/'H' promise instead of rendering inconsistently.
         boolean hasHour12 = false;
         boolean hasHour24 = false;
         boolean hasAmPm = false;
-        for (Field field : fields) {
-            if (field.type == FieldType.HOUR12) hasHour12 = true;
-            if (field.type == FieldType.HOUR24) hasHour24 = true;
-            if (field.type == FieldType.AMPM) hasAmPm = true;
+        for (DateTimeField field : fields) {
+            if (field.type == DateTimeFieldType.HOUR12) hasHour12 = true;
+            if (field.type == DateTimeFieldType.HOUR24) hasHour24 = true;
+            if (field.type == DateTimeFieldType.AMPM) hasAmPm = true;
         }
         if (hasHour12 && hasHour24) {
             throw new IllegalArgumentException(
@@ -491,16 +495,17 @@ final class DataStylePattern {
         }
     }
 
-    private static void mergeSecondsFraction(List<Field> fields) {
+    private static void mergeSecondsFraction(List<DateTimeField> fields) {
         for (int i = 0; i + 2 < fields.size(); i++) {
-            Field secondField = fields.get(i);
-            Field dotField = fields.get(i + 1);
-            Field fractionField = fields.get(i + 2);
-            if (secondField.type == FieldType.SECOND
-                    && dotField.type == FieldType.TEXT
+            DateTimeField secondField = fields.get(i);
+            DateTimeField dotField = fields.get(i + 1);
+            DateTimeField fractionField = fields.get(i + 2);
+            if (secondField.type == DateTimeFieldType.SECOND
+                    && dotField.type == DateTimeFieldType.TEXT
                     && ".".equals(dotField.text)
-                    && fractionField.type == FieldType.FRACTION_SECOND) {
-                Field merged = Field.ofSecond(
+                    && fractionField.type
+                            == DateTimeFieldType.FRACTION_SECOND) {
+                DateTimeField merged = DateTimeField.ofSecond(
                         secondField.length, fractionField.length);
                 fields.set(i, merged);
                 fields.remove(i + 2);
@@ -509,13 +514,13 @@ final class DataStylePattern {
         }
     }
 
-    private static void mergeAdjacentText(List<Field> fields) {
+    private static void mergeAdjacentText(List<DateTimeField> fields) {
         for (int i = 0; i < fields.size() - 1; ) {
-            Field current = fields.get(i);
-            Field next = fields.get(i + 1);
-            if (current.type == FieldType.TEXT
-                    && next.type == FieldType.TEXT) {
-                fields.set(i, Field.ofText(current.text + next.text));
+            DateTimeField current = fields.get(i);
+            DateTimeField next = fields.get(i + 1);
+            if (current.type == DateTimeFieldType.TEXT
+                    && next.type == DateTimeFieldType.TEXT) {
+                fields.set(i, DateTimeField.ofText(current.text + next.text));
                 fields.remove(i + 1);
             } else {
                 i++;

--- a/src/com/github/miachm/sods/DataStylePattern.java
+++ b/src/com/github/miachm/sods/DataStylePattern.java
@@ -1,0 +1,639 @@
+// SPDX-FileType: SOURCE
+// SPDX-License-Identifier: Unlicense
+
+package com.github.miachm.sods;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Parses the pattern strings accepted by {@link Style#setDataStyle(String)}.
+ *
+ * <p>Every pattern is one of three kinds, chosen automatically from its
+ * content: plain text ({@code @}), a date/time pattern (letters from
+ * {@code java.time.format.DateTimeFormatter}), or a numeric pattern
+ * (digits, grouping, decimal point, percent, scientific notation).
+ * A digit placeholder ({@code 0} or {@code #}) anywhere makes the whole
+ * pattern numeric, even if date/time-looking letters are also present.
+ *
+ * <p>{@link StyleWriter} translates the result into ODF
+ * {@code number:text-style} / {@code number:date-style} /
+ * {@code number:time-style} / {@code number:number-style} /
+ * {@code number:percentage-style} XML. Each kind's tokens are detailed in
+ * its own section below.
+ *
+ * <h2>Date/time tokens</h2>
+ * <p>{@code y M d G E w Q q H h m s S a} use the exact semantics of the
+ * corresponding {@code java.time.format.DateTimeFormatter} pattern letters.
+ * Case is significant: {@code s} is whole seconds, {@code S} is
+ * fraction-of-second. Repeat count controls padding, same as
+ * {@code DateTimeFormatter}.
+ * <ul>
+ *     <li>{@code y} -- year-of-era. &lt;4 repeats = 2-digit, 4+ = 4-digit
+ *     (ODF only has these two year styles).</li>
+ *     <li>{@code M} -- month-of-year. 1 = unpadded numeric, 2 = padded
+ *     numeric, 3 = abbreviated name, 4+ = full name.</li>
+ *     <li>{@code d} -- day-of-month. 1 = unpadded, 2+ = padded.</li>
+ *     <li>{@code G} -- era (e.g. AD). &lt;4 repeats = short, 4+ = long.</li>
+ *     <li>{@code E} -- day-of-week name (e.g. Tue), always textual --
+ *     matches ODF's {@code number:day-of-week}, which has no numeric form.
+ *     &lt;4 = short, 4+ = long. Lowercase {@code e}/{@code c} aren't
+ *     supported: they can mean a numeric weekday at low repeat counts,
+ *     which ODF can't render.</li>
+ *     <li>{@code w} -- week-of-year. ODF's {@code number:week-of-year} has
+ *     no style attribute, so repeat count is accepted but ignored.
+ *     Uppercase {@code W} (week-of-month) isn't supported -- ODF has no
+ *     element for it.</li>
+ *     <li>{@code Q}/{@code q} -- quarter-of-year. Both cases accepted, same
+ *     meaning. Unlike {@code Y}/{@code D}/{@code A}, the case split in real
+ *     {@code DateTimeFormatter} is only grammatical context, and ODF's
+ *     {@code number:quarter} has no such distinction to lose. 1-2 repeats
+ *     = short (numeric), 3+ = long (textual).</li>
+ *     <li>{@code H} -- hour-of-day, 24h. 1 = unpadded, 2+ = padded. Must
+ *     not pair with {@code a} -- ODF always renders 12-hour when an AM/PM
+ *     marker is present, so that combination is contradictory and
+ *     rejected.</li>
+ *     <li>{@code h} -- clock-hour-of-am-pm, 12h. Requires a paired
+ *     {@code a} -- ODF has no attribute distinguishing 12h from 24h, so a
+ *     bare {@code h} would silently render as 24h otherwise. Same padding
+ *     rule.</li>
+ *     <li>{@code m} -- minute-of-hour. 1 = unpadded, 2+ = padded.</li>
+ *     <li>{@code s} -- second-of-minute. 1 = unpadded, 2+ = padded.</li>
+ *     <li>{@code S} -- fraction-of-second digits. Only valid right after a
+ *     {@code s} run and a literal {@code .}, e.g. {@code "ss.SSS"} =
+ *     2-digit seconds + 3 fractional digits. A standalone {@code S} is
+ *     rejected -- ODF's {@code number:seconds} always needs a whole-seconds
+ *     field to attach the fraction to.</li>
+ *     <li>{@code a} -- am-pm-of-day marker.</li>
+ * </ul>
+ *
+ * <h3>Date/time limitations</h3>
+ * <p>Uppercase {@code Y} (week-based-year), {@code D} (day-of-year), and
+ * {@code A} (milli-of-day) are rejected. ODF 1.2 has nothing to map those onto.
+ * This rejection is unconditional, since these three letters have no valid
+ * meaning anywhere in this grammar and are always a typo signal.
+ *
+ * <p>No zone/offset, nano-of-second, padding, or optional-section syntax.
+ * ODF 1.2 has nothing to map those onto.
+ *
+ * <h3>YYYY-MM-DD grandfathered exception</h3>
+ * <p>To keep backward compatibility, {@code "YYYY-MM-DD"} is accepted and
+ * parses like {@code "yyyy-MM-dd"}.
+ * No other uppercase usage gets this treatment.
+ *
+ * <h2>Numeric tokens</h2>
+ * <p>Mostly matches {@code java.text.DecimalFormat}'s own convention.
+ * <ul>
+ *     <li>{@code 0} -- mandatory digit.</li>
+ *     <li>{@code #} -- optional digit.</li>
+ *     <li>{@code ,} -- grouping (thousands) flag; not placed literally, ODF
+ *     inserts it.</li>
+ *     <li>{@code .} -- splits integer and fraction digit runs.</li>
+ *     <li>{@code %} -- marks the pattern as a percentage. Stripped wherever
+ *     it appears, always re-emitted as a trailing literal {@code %}. Not
+ *     combinable with {@code E} -- ODF's percentage-style only allows a
+ *     plain number, not scientific notation.</li>
+ *     <li>{@code E} -- scientific notation, matching
+ *     {@code java.text.DecimalFormat}'s own convention (e.g.
+ *     {@code "0.00E00"}). Must be followed by at least one {@code 0}; that
+ *     count sets the minimum exponent digits.</li>
+ * </ul>
+ *
+ * <h2>Quoting and validation</h2>
+ * <p>{@code '...'} quotes literal text. {@code ''} inside an open quote is
+ * a literal single quote, e.g. {@code "'it''s'"} → {@code it's}.
+ * A standalone {@code ''} with nothing else around it is the empty string.
+ *
+ * <p>In a date/time pattern, any unquoted character that isn't a token
+ * letter above must be one of the common separators
+ * {@code space - : / . , T}, or it's rejected. This catches a mistyped or
+ * unsupported letter (e.g. {@code N}, or uppercase
+ * {@code Y}/{@code D}/{@code A}) instead of silently treating it as
+ * decoration.
+ *
+ * <p>Numeric patterns don't have that restriction -- unquoted prefix/suffix
+ * text (currency symbols, unit labels) is common and unambiguous there.
+ * The one exception is uppercase {@code Y}/{@code D}/{@code A}, which
+ * stay rejected even in a numeric pattern.
+ *
+ * <h2>References</h2>
+ * <p>ODF's {@code number:*-style} elements are defined in OpenDocument
+ * v1.2 Part 1, section 16.27 (date/time/number/percentage styles); the
+ * RelaxNG schema has the exact element and attribute list this class was
+ * checked against.
+ *
+ * @see <a href="https://docs.oasis-open.org/office/v1.2/os/OpenDocument-v1.2-os-part1.html#__RefHeading__1416346_253892949">OpenDocument v1.2 Part 1: OpenDocument Schema</a>
+ * @see <a href="https://docs.oasis-open.org/office/v1.2/os/OpenDocument-v1.2-os-schema.rng">OpenDocument v1.2 RelaxNG schema</a>
+ * @see <a href="https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html">java.time.format.DateTimeFormatter</a>
+ * @see <a href="https://docs.oracle.com/javase/8/docs/api/java/text/DecimalFormat.html">java.text.DecimalFormat</a>
+ */
+final class DataStylePattern {
+
+    enum Kind { TEXT, DATE_TIME, NUMBER }
+
+    enum FieldType {
+        YEAR, MONTH, DAY, ERA, DAY_OF_WEEK, WEEK_OF_YEAR, QUARTER,
+        HOUR24, HOUR12, MINUTE, SECOND, FRACTION_SECOND, AMPM, TEXT
+    }
+
+    static final class Field {
+        final FieldType type;
+        final int length;
+        final int decimalPlaces;
+        final String text;
+
+        private Field(
+                FieldType type, int length, int decimalPlaces, String text) {
+            this.type = type;
+            this.length = length;
+            this.decimalPlaces = decimalPlaces;
+            this.text = text;
+        }
+
+        static Field of(FieldType type, int length) {
+            return new Field(type, length, 0, null);
+        }
+
+        static Field ofSecond(int length, int decimalPlaces) {
+            return new Field(FieldType.SECOND, length, decimalPlaces, null);
+        }
+
+        static Field ofText(String text) {
+            return new Field(FieldType.TEXT, 0, 0, text);
+        }
+    }
+
+    static final class NumberSpec {
+        final String prefix;
+        final String suffix;
+        final int minIntegerDigits;
+        final int decimalPlaces;
+        final boolean grouping;
+        final boolean percentage;
+        final boolean scientific;
+        final int minExponentDigits;
+
+        NumberSpec(
+                String prefix,
+                String suffix,
+                int minIntegerDigits,
+                int decimalPlaces,
+                boolean grouping,
+                boolean percentage,
+                boolean scientific,
+                int minExponentDigits) {
+            this.prefix = prefix;
+            this.suffix = suffix;
+            this.minIntegerDigits = minIntegerDigits;
+            this.decimalPlaces = decimalPlaces;
+            this.grouping = grouping;
+            this.percentage = percentage;
+            this.scientific = scientific;
+            this.minExponentDigits = minExponentDigits;
+        }
+    }
+
+    private static final String DATE_TIME_LETTERS = "yMdGEwQqHhmsSa";
+    private static final String NUMBER_TOKENS = "0#";
+    // Y/D/A have no valid meaning anywhere in this grammar (unlike W/e/c,
+    // which are only invalid in DATE_TIME context -- W could be a real
+    // "Watts" unit label in a NUMBER pattern). So these three are rejected
+    // unconditionally, even inside an otherwise-permissive NUMBER pattern.
+    private static final String ALWAYS_INVALID_LETTERS = "YDA";
+    private static final String LEGACY_ISO_DATE_LITERAL = "YYYY-MM-DD";
+    private static final String CANONICAL_ISO_DATE = "yyyy-MM-dd";
+    // Package-private so DataStyleReader can reuse it as the source of
+    // truth for quoting.
+    static final String ALLOWED_BARE_LITERALS = " -:/.,T";
+
+    final Kind kind;
+    final List<Field> dateTimeFields;
+    final NumberSpec numberSpec;
+
+    private DataStylePattern(
+            Kind kind, List<Field> dateTimeFields, NumberSpec numberSpec) {
+        this.kind = kind;
+        this.dateTimeFields = dateTimeFields;
+        this.numberSpec = numberSpec;
+    }
+
+    boolean hasDateFields() {
+        if (dateTimeFields == null) return false;
+        for (Field field : dateTimeFields) {
+            switch (field.type) {
+                case YEAR: case MONTH: case DAY:
+                case ERA: case DAY_OF_WEEK: case WEEK_OF_YEAR: case QUARTER:
+                    return true;
+                default:
+                    break;
+            }
+        }
+        return false;
+    }
+
+    static DataStylePattern parse(String pattern) {
+        if (pattern == null) {
+            throw new IllegalArgumentException(
+                    "Data style pattern cannot be null");
+        }
+        if (Style.PLAIN_DATA_STYLE.equals(pattern)) {
+            return new DataStylePattern(Kind.TEXT, null, null);
+        }
+        if (LEGACY_ISO_DATE_LITERAL.equals(pattern)) {
+            // Permanent compat shim for the pre-existing literal.
+            // See class Javadoc.
+            return parse(CANONICAL_ISO_DATE);
+        }
+
+        Flat flat = flatten(pattern);
+
+        boolean hasLetter = false;
+        boolean hasDigit = false;
+        int invalidIndex = -1;
+        char invalidChar = 0;
+        for (int i = 0; i < flat.text.length(); i++) {
+            if (flat.literal[i]) continue;
+            char c = flat.text.charAt(i);
+            if (DATE_TIME_LETTERS.indexOf(c) >= 0) hasLetter = true;
+            if (NUMBER_TOKENS.indexOf(c) >= 0) hasDigit = true;
+            if (invalidIndex < 0 && ALWAYS_INVALID_LETTERS.indexOf(c) >= 0) {
+                invalidIndex = i;
+                invalidChar = c;
+            }
+        }
+
+        // Checked before classification: Y/D/A are typo signals no
+        // matter what kind the rest of the pattern turns out to be, so
+        // they can't hide behind an incidental digit placeholder (e.g.
+        // "YYYY-MM-01" must not silently become a NUMBER pattern).
+        if (invalidIndex >= 0) {
+            throw new IllegalArgumentException("Unrecognized character '"
+                    + invalidChar + "' in data style pattern at index "
+                    + invalidIndex + " -- uppercase Y/D/A have no valid "
+                    + "meaning in this grammar; wrap literal text in "
+                    + "single quotes, e.g. '" + invalidChar
+                    + "', or remove it: " + pattern);
+        }
+
+        // A digit placeholder always wins classification. Numeric unit
+        // labels like "0.00 m" or "0.00 s" reuse letters that are also
+        // date/time tokens (m, s, h, d, y, a); requiring those to be
+        // quoted would make ordinary numeric patterns awkward. So the
+        // stricter DATE_TIME allowlist only kicks in when no digit
+        // placeholder is present at all.
+        if (hasDigit) {
+            return new DataStylePattern(
+                    Kind.NUMBER, null, parseNumber(flat, pattern));
+        }
+        if (hasLetter) {
+            return new DataStylePattern(
+                    Kind.DATE_TIME, parseDateTime(flat, pattern), null);
+        }
+        throw new IllegalArgumentException(
+                "Unrecognized data style pattern (expected date/time "
+                        + "letters like y,M,d,H,h,m,s,S,a or numeric "
+                        + "placeholders like 0,#): " + pattern);
+    }
+
+    private static final class Flat {
+        final String text;
+        final boolean[] literal;
+
+        Flat(String text, boolean[] literal) {
+            this.text = text;
+            this.literal = literal;
+        }
+    }
+
+    private static Flat flatten(String pattern) {
+        StringBuilder text = new StringBuilder();
+        List<Boolean> literalFlags = new ArrayList<>();
+        int i = 0;
+        int n = pattern.length();
+        while (i < n) {
+            char c = pattern.charAt(i);
+            if (c == '\'') {
+                i++; // consume opening quote
+                while (true) {
+                    if (i >= n) {
+                        throw new IllegalArgumentException(
+                                "Unterminated ' (literal quote) in data "
+                                        + "style pattern: " + pattern);
+                    }
+                    char cc = pattern.charAt(i);
+                    if (cc == '\'') {
+                        if (i + 1 < n && pattern.charAt(i + 1) == '\'') {
+                            // '' inside an open quote is an escaped
+                            // literal quote character.
+                            text.append('\'');
+                            literalFlags.add(true);
+                            i += 2;
+                        } else {
+                            i++; // consume closing quote
+                            break;
+                        }
+                    } else {
+                        text.append(cc);
+                        literalFlags.add(true);
+                        i++;
+                    }
+                }
+            } else {
+                text.append(c);
+                literalFlags.add(false);
+                i++;
+            }
+        }
+        boolean[] literal = new boolean[literalFlags.size()];
+        for (int k = 0; k < literal.length; k++) {
+            literal[k] = literalFlags.get(k);
+        }
+        return new Flat(text.toString(), literal);
+    }
+
+    private static FieldType letterFieldType(char c) {
+        // Case-sensitive, matching DateTimeFormatter's own letters. See
+        // class Javadoc for why Y/D/A are excluded, why Q/q are aliased,
+        // and why only uppercase E is supported.
+        switch (c) {
+            case 'y': return FieldType.YEAR;
+            case 'M': return FieldType.MONTH;
+            case 'd': return FieldType.DAY;
+            case 'G': return FieldType.ERA;
+            case 'E': return FieldType.DAY_OF_WEEK;
+            case 'w': return FieldType.WEEK_OF_YEAR;
+            case 'Q': case 'q': return FieldType.QUARTER;
+            case 'H': return FieldType.HOUR24;
+            case 'h': return FieldType.HOUR12;
+            case 'm': return FieldType.MINUTE;
+            case 's': return FieldType.SECOND;
+            case 'S': return FieldType.FRACTION_SECOND;
+            case 'a': return FieldType.AMPM;
+            default: return null;
+        }
+    }
+
+    private static List<Field> parseDateTime(
+            Flat flat, String originalPattern) {
+        List<Field> fields = new ArrayList<>();
+        String text = flat.text;
+        int n = text.length();
+        int i = 0;
+        while (i < n) {
+            if (flat.literal[i]) {
+                int j = i;
+                StringBuilder literalText = new StringBuilder();
+                while (j < n && flat.literal[j]) {
+                    literalText.append(text.charAt(j));
+                    j++;
+                }
+                fields.add(Field.ofText(literalText.toString()));
+                i = j;
+                continue;
+            }
+
+            char c = text.charAt(i);
+            FieldType type = letterFieldType(c);
+            if (type != null) {
+                int j = i;
+                while (j < n && !flat.literal[j]
+                        && letterFieldType(text.charAt(j)) == type) {
+                    j++;
+                }
+                fields.add(Field.of(type, j - i));
+                i = j;
+                continue;
+            }
+
+            if (ALLOWED_BARE_LITERALS.indexOf(c) >= 0) {
+                fields.add(Field.ofText(String.valueOf(c)));
+                i++;
+                continue;
+            }
+
+            throw new IllegalArgumentException("Unrecognized character '"
+                    + c + "' in date/time data style pattern at index " + i
+                    + "; wrap literal text in single quotes, e.g. '" + c
+                    + "', or remove it: " + originalPattern);
+        }
+
+        mergeSecondsFraction(fields);
+        mergeAdjacentText(fields);
+        validateHourAmPmConsistency(fields, originalPattern);
+        validateNoStandaloneFractionSeconds(fields, originalPattern);
+        return fields;
+    }
+
+    private static void validateNoStandaloneFractionSeconds(
+            List<Field> fields, String originalPattern) {
+        // mergeSecondsFraction folds a valid "s.S" run into one SECOND
+        // field. Anything left over here wasn't preceded by a
+        // whole-seconds field, which ODF has no way to render.
+        for (Field field : fields) {
+            if (field.type == FieldType.FRACTION_SECOND) {
+                throw new IllegalArgumentException(
+                        "Data style pattern uses 'S' (fractional-second "
+                                + "digits) without an immediately "
+                                + "preceding whole-seconds field and "
+                                + "literal '.' -- 'S' only means "
+                                + "fraction-of-second when it directly "
+                                + "follows \"s.\", e.g. \"ss.SSS\": "
+                                + originalPattern);
+            }
+        }
+    }
+
+    private static void validateHourAmPmConsistency(
+            List<Field> fields, String originalPattern) {
+        // ODF's number:hours has no 12h/24h attribute -- a sibling
+        // number:am-pm element is what decides it. Enforce the pairing
+        // 'h'/'H' promise instead of rendering inconsistently.
+        boolean hasHour12 = false;
+        boolean hasHour24 = false;
+        boolean hasAmPm = false;
+        for (Field field : fields) {
+            if (field.type == FieldType.HOUR12) hasHour12 = true;
+            if (field.type == FieldType.HOUR24) hasHour24 = true;
+            if (field.type == FieldType.AMPM) hasAmPm = true;
+        }
+        if (hasHour12 && hasHour24) {
+            throw new IllegalArgumentException(
+                    "Data style pattern mixes both 'H' (24-hour) and 'h' "
+                            + "(12-hour) tokens: " + originalPattern);
+        }
+        if (hasHour12 && !hasAmPm) {
+            throw new IllegalArgumentException(
+                    "Data style pattern uses 'h' (12-hour clock) without "
+                            + "a paired 'a' AM/PM marker; ODF cannot "
+                            + "distinguish that from a 24-hour clock, so "
+                            + "it would render the hour wrong. Add 'a', "
+                            + "or use 'H' for a 24-hour clock: "
+                            + originalPattern);
+        }
+        if (hasHour24 && hasAmPm) {
+            throw new IllegalArgumentException(
+                    "Data style pattern uses 'H' (24-hour clock) "
+                            + "together with an 'a' AM/PM marker; ODF "
+                            + "always renders a 12-hour clock whenever an "
+                            + "AM/PM marker is present, so this "
+                            + "combination is contradictory. Use 'h' for "
+                            + "a 12-hour clock instead: " + originalPattern);
+        }
+    }
+
+    private static void mergeSecondsFraction(List<Field> fields) {
+        for (int i = 0; i + 2 < fields.size(); i++) {
+            Field secondField = fields.get(i);
+            Field dotField = fields.get(i + 1);
+            Field fractionField = fields.get(i + 2);
+            if (secondField.type == FieldType.SECOND
+                    && dotField.type == FieldType.TEXT
+                    && ".".equals(dotField.text)
+                    && fractionField.type == FieldType.FRACTION_SECOND) {
+                Field merged = Field.ofSecond(
+                        secondField.length, fractionField.length);
+                fields.set(i, merged);
+                fields.remove(i + 2);
+                fields.remove(i + 1);
+            }
+        }
+    }
+
+    private static void mergeAdjacentText(List<Field> fields) {
+        for (int i = 0; i < fields.size() - 1; ) {
+            Field current = fields.get(i);
+            Field next = fields.get(i + 1);
+            if (current.type == FieldType.TEXT
+                    && next.type == FieldType.TEXT) {
+                fields.set(i, Field.ofText(current.text + next.text));
+                fields.remove(i + 1);
+            } else {
+                i++;
+            }
+        }
+    }
+
+    private static NumberSpec parseNumber(
+            Flat flat, String originalPattern) {
+        String text = flat.text;
+        boolean[] literal = flat.literal;
+        int n = text.length();
+
+        // 'E' marks scientific notation -> ODF's number:scientific-number.
+        // Only the first unquoted 'E' counts; the mantissa scan stops
+        // there so exponent digits aren't mistaken for mantissa digits.
+        int eIndex = -1;
+        for (int i = 0; i < n; i++) {
+            if (!literal[i] && text.charAt(i) == 'E') {
+                eIndex = i;
+                break;
+            }
+        }
+        boolean scientific = eIndex >= 0;
+        int mantissaEnd = scientific ? eIndex : n;
+
+        int firstDigit = -1;
+        int lastDigit = -1;
+        for (int i = 0; i < mantissaEnd; i++) {
+            if (!literal[i]
+                    && (text.charAt(i) == '0' || text.charAt(i) == '#')) {
+                if (firstDigit < 0) firstDigit = i;
+                lastDigit = i;
+            }
+        }
+        if (firstDigit < 0) {
+            throw new IllegalArgumentException(
+                    "Numeric data style pattern must contain at least "
+                            + "one '0' or '#': " + originalPattern);
+        }
+
+        int minExponentDigits = 0;
+        int suffixStart = lastDigit + 1;
+        if (scientific) {
+            int j = eIndex + 1;
+            int exponentDigits = 0;
+            while (j < n && !literal[j]
+                    && (text.charAt(j) == '0' || text.charAt(j) == '#')) {
+                if (text.charAt(j) == '0') exponentDigits++;
+                j++;
+            }
+            if (exponentDigits == 0) {
+                throw new IllegalArgumentException(
+                        "Scientific notation pattern must have at least "
+                                + "one '0' after 'E': " + originalPattern);
+            }
+            minExponentDigits = exponentDigits;
+            suffixStart = j;
+        }
+
+        boolean percentage = false;
+        StringBuilder prefix = new StringBuilder();
+        for (int i = 0; i < firstDigit; i++) {
+            if (!literal[i] && text.charAt(i) == '%') {
+                percentage = true;
+            } else {
+                prefix.append(text.charAt(i));
+            }
+        }
+        StringBuilder suffix = new StringBuilder();
+        for (int i = suffixStart; i < n; i++) {
+            if (!literal[i] && text.charAt(i) == '%') {
+                percentage = true;
+            } else {
+                suffix.append(text.charAt(i));
+            }
+        }
+
+        boolean grouping = false;
+        boolean afterDot = false;
+        boolean sawDot = false;
+        StringBuilder integerPart = new StringBuilder();
+        StringBuilder fractionPart = new StringBuilder();
+        for (int i = firstDigit; i <= lastDigit; i++) {
+            char c = text.charAt(i);
+            boolean lit = literal[i];
+            if (!lit && c == '%') {
+                percentage = true;
+            } else if (!lit && c == ',') {
+                grouping = true;
+            } else if (!lit && c == '.') {
+                if (sawDot) {
+                    throw new IllegalArgumentException(
+                            "Numeric data style pattern cannot contain "
+                                    + "more than one decimal point: "
+                                    + originalPattern);
+                }
+                sawDot = true;
+                afterDot = true;
+            } else if (!lit && (c == '0' || c == '#')) {
+                if (afterDot) fractionPart.append(c);
+                else integerPart.append(c);
+            }
+        }
+
+        int minIntegerDigits = 0;
+        for (int i = 0; i < integerPart.length(); i++) {
+            if (integerPart.charAt(i) == '0') minIntegerDigits++;
+        }
+        int decimalPlaces = fractionPart.length();
+
+        if (scientific && percentage) {
+            // ODF's number:percentage-style content model only allows a
+            // plain number:number child, not number:scientific-number --
+            // confirmed from the RelaxNG schema.
+            throw new IllegalArgumentException(
+                    "Scientific notation cannot be combined with a "
+                            + "percentage marker: " + originalPattern);
+        }
+
+        return new NumberSpec(
+                prefix.toString(),
+                suffix.toString(),
+                minIntegerDigits,
+                decimalPlaces,
+                grouping,
+                percentage,
+                scientific,
+                minExponentDigits);
+    }
+}

--- a/tests/com/github/miachm/sods/DataStylePatternTest.java
+++ b/tests/com/github/miachm/sods/DataStylePatternTest.java
@@ -23,16 +23,21 @@ public class DataStylePatternTest {
         assertEquals(DataStylePattern.Kind.DATE_TIME, pattern.kind);
         assertTrue(pattern.hasDateFields());
 
-        List<DataStylePattern.Field> fields = pattern.dateTimeFields;
+        List<DataStylePattern.DateTimeField> fields = pattern.dateTimeFields;
         assertEquals(5, fields.size());
-        assertEquals(DataStylePattern.FieldType.YEAR, fields.get(0).type);
+        assertEquals(
+                DataStylePattern.DateTimeFieldType.YEAR, fields.get(0).type);
         assertEquals(4, fields.get(0).length);
-        assertEquals(DataStylePattern.FieldType.TEXT, fields.get(1).type);
+        assertEquals(
+                DataStylePattern.DateTimeFieldType.TEXT, fields.get(1).type);
         assertEquals("-", fields.get(1).text);
-        assertEquals(DataStylePattern.FieldType.MONTH, fields.get(2).type);
+        assertEquals(
+                DataStylePattern.DateTimeFieldType.MONTH, fields.get(2).type);
         assertEquals(2, fields.get(2).length);
-        assertEquals(DataStylePattern.FieldType.TEXT, fields.get(3).type);
-        assertEquals(DataStylePattern.FieldType.DAY, fields.get(4).type);
+        assertEquals(
+                DataStylePattern.DateTimeFieldType.TEXT, fields.get(3).type);
+        assertEquals(
+                DataStylePattern.DateTimeFieldType.DAY, fields.get(4).type);
         assertEquals(2, fields.get(4).length);
     }
 
@@ -64,9 +69,9 @@ public class DataStylePatternTest {
         assertEquals(DataStylePattern.Kind.DATE_TIME, pattern.kind);
         assertTrue(pattern.hasDateFields());
 
-        DataStylePattern.Field secondField = null;
-        for (DataStylePattern.Field field : pattern.dateTimeFields) {
-            if (field.type == DataStylePattern.FieldType.SECOND) {
+        DataStylePattern.DateTimeField secondField = null;
+        for (DataStylePattern.DateTimeField field : pattern.dateTimeFields) {
+            if (field.type == DataStylePattern.DateTimeFieldType.SECOND) {
                 secondField = field;
             }
         }
@@ -74,9 +79,9 @@ public class DataStylePatternTest {
         assertEquals(2, secondField.length);
         assertEquals(3, secondField.decimalPlaces);
 
-        DataStylePattern.Field textT = null;
-        for (DataStylePattern.Field field : pattern.dateTimeFields) {
-            if (field.type == DataStylePattern.FieldType.TEXT
+        DataStylePattern.DateTimeField textT = null;
+        for (DataStylePattern.DateTimeField field : pattern.dateTimeFields) {
+            if (field.type == DataStylePattern.DateTimeFieldType.TEXT
                     && "T".equals(field.text)) {
                 textT = field;
             }
@@ -91,8 +96,8 @@ public class DataStylePatternTest {
         // one "seconds" concept.
         DataStylePattern pattern = DataStylePattern.parse("ss.SSS");
         assertEquals(1, pattern.dateTimeFields.size());
-        DataStylePattern.Field second = pattern.dateTimeFields.get(0);
-        assertEquals(DataStylePattern.FieldType.SECOND, second.type);
+        DataStylePattern.DateTimeField second = pattern.dateTimeFields.get(0);
+        assertEquals(DataStylePattern.DateTimeFieldType.SECOND, second.type);
         assertEquals(2, second.length);
         assertEquals(3, second.decimalPlaces);
     }
@@ -140,11 +145,11 @@ public class DataStylePatternTest {
         DataStylePattern pattern = DataStylePattern.parse("hh:mm a");
         boolean sawHour12 = false;
         boolean sawAmPm = false;
-        for (DataStylePattern.Field field : pattern.dateTimeFields) {
-            if (field.type == DataStylePattern.FieldType.HOUR12) {
+        for (DataStylePattern.DateTimeField field : pattern.dateTimeFields) {
+            if (field.type == DataStylePattern.DateTimeFieldType.HOUR12) {
                 sawHour12 = true;
             }
-            if (field.type == DataStylePattern.FieldType.AMPM) {
+            if (field.type == DataStylePattern.DateTimeFieldType.AMPM) {
                 sawAmPm = true;
             }
         }
@@ -155,12 +160,14 @@ public class DataStylePatternTest {
     @Test
     public void monthTextualFormsUseTextualLength() {
         DataStylePattern abbrev = DataStylePattern.parse("MMM d, yyyy");
-        DataStylePattern.Field monthAbbrev = abbrev.dateTimeFields.get(0);
-        assertEquals(DataStylePattern.FieldType.MONTH, monthAbbrev.type);
+        DataStylePattern.DateTimeField monthAbbrev =
+                abbrev.dateTimeFields.get(0);
+        assertEquals(
+                DataStylePattern.DateTimeFieldType.MONTH, monthAbbrev.type);
         assertEquals(3, monthAbbrev.length);
 
         DataStylePattern full = DataStylePattern.parse("MMMM d, yyyy");
-        DataStylePattern.Field monthFull = full.dateTimeFields.get(0);
+        DataStylePattern.DateTimeField monthFull = full.dateTimeFields.get(0);
         assertEquals(4, monthFull.length);
     }
 
@@ -169,8 +176,8 @@ public class DataStylePatternTest {
         DataStylePattern pattern =
                 DataStylePattern.parse("yyyy 'o''clock' MM");
         StringBuilder combinedText = new StringBuilder();
-        for (DataStylePattern.Field field : pattern.dateTimeFields) {
-            if (field.type == DataStylePattern.FieldType.TEXT) {
+        for (DataStylePattern.DateTimeField field : pattern.dateTimeFields) {
+            if (field.type == DataStylePattern.DateTimeFieldType.TEXT) {
                 combinedText.append(field.text);
             }
         }
@@ -404,8 +411,8 @@ public class DataStylePatternTest {
                 DataStylePattern.parse("yyyy-MM-dd'notes'");
         assertEquals(DataStylePattern.Kind.DATE_TIME, pattern.kind);
         StringBuilder combinedText = new StringBuilder();
-        for (DataStylePattern.Field field : pattern.dateTimeFields) {
-            if (field.type == DataStylePattern.FieldType.TEXT) {
+        for (DataStylePattern.DateTimeField field : pattern.dateTimeFields) {
+            if (field.type == DataStylePattern.DateTimeFieldType.TEXT) {
                 combinedText.append(field.text);
             }
         }
@@ -468,7 +475,7 @@ public class DataStylePatternTest {
     public void eraFieldParsesAndCountsAsDateField() {
         DataStylePattern shortEra = DataStylePattern.parse("G yyyy");
         assertEquals(
-                DataStylePattern.FieldType.ERA,
+                DataStylePattern.DateTimeFieldType.ERA,
                 shortEra.dateTimeFields.get(0).type);
         assertTrue(shortEra.hasDateFields());
 
@@ -480,7 +487,7 @@ public class DataStylePatternTest {
     public void dayOfWeekFieldParsesAndCountsAsDateField() {
         DataStylePattern pattern = DataStylePattern.parse("EEE, MMM d");
         assertEquals(
-                DataStylePattern.FieldType.DAY_OF_WEEK,
+                DataStylePattern.DateTimeFieldType.DAY_OF_WEEK,
                 pattern.dateTimeFields.get(0).type);
         assertTrue(pattern.hasDateFields());
     }
@@ -498,7 +505,7 @@ public class DataStylePatternTest {
         // ODF's number:week-of-year has no style attribute at all.
         DataStylePattern pattern = DataStylePattern.parse("w yyyy");
         assertEquals(
-                DataStylePattern.FieldType.WEEK_OF_YEAR,
+                DataStylePattern.DateTimeFieldType.WEEK_OF_YEAR,
                 pattern.dateTimeFields.get(0).type);
         assertTrue(pattern.hasDateFields());
     }
@@ -515,10 +522,10 @@ public class DataStylePatternTest {
         DataStylePattern upper = DataStylePattern.parse("Q yyyy");
         DataStylePattern lower = DataStylePattern.parse("q yyyy");
         assertEquals(
-                DataStylePattern.FieldType.QUARTER,
+                DataStylePattern.DateTimeFieldType.QUARTER,
                 upper.dateTimeFields.get(0).type);
         assertEquals(
-                DataStylePattern.FieldType.QUARTER,
+                DataStylePattern.DateTimeFieldType.QUARTER,
                 lower.dateTimeFields.get(0).type);
     }
 

--- a/tests/com/github/miachm/sods/DataStylePatternTest.java
+++ b/tests/com/github/miachm/sods/DataStylePatternTest.java
@@ -1,0 +1,585 @@
+// SPDX-FileType: SOURCE
+// SPDX-License-Identifier: Unlicense
+
+package com.github.miachm.sods;
+
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static org.testng.AssertJUnit.*;
+
+public class DataStylePatternTest {
+
+    @Test
+    public void plainMarkerIsText() {
+        DataStylePattern pattern = DataStylePattern.parse("@");
+        assertEquals(DataStylePattern.Kind.TEXT, pattern.kind);
+    }
+
+    @Test
+    public void isoDateHasThreeZeroPaddedFields() {
+        DataStylePattern pattern = DataStylePattern.parse("yyyy-MM-dd");
+        assertEquals(DataStylePattern.Kind.DATE_TIME, pattern.kind);
+        assertTrue(pattern.hasDateFields());
+
+        List<DataStylePattern.Field> fields = pattern.dateTimeFields;
+        assertEquals(5, fields.size());
+        assertEquals(DataStylePattern.FieldType.YEAR, fields.get(0).type);
+        assertEquals(4, fields.get(0).length);
+        assertEquals(DataStylePattern.FieldType.TEXT, fields.get(1).type);
+        assertEquals("-", fields.get(1).text);
+        assertEquals(DataStylePattern.FieldType.MONTH, fields.get(2).type);
+        assertEquals(2, fields.get(2).length);
+        assertEquals(DataStylePattern.FieldType.TEXT, fields.get(3).type);
+        assertEquals(DataStylePattern.FieldType.DAY, fields.get(4).type);
+        assertEquals(2, fields.get(4).length);
+    }
+
+    @Test
+    public void legacyUppercaseIsoDateLiteralIsGrandfathered() {
+        // Pre-existing literal (Style.ISO_DATE_DATA_STYLE since v1.6.0).
+        // Must parse like "yyyy-MM-dd" forever, even though bare
+        // uppercase Y/D elsewhere is rejected.
+        DataStylePattern legacy = DataStylePattern.parse("YYYY-MM-DD");
+        DataStylePattern canonical = DataStylePattern.parse("yyyy-MM-dd");
+        assertEquals(canonical.kind, legacy.kind);
+        assertEquals(
+                canonical.dateTimeFields.size(),
+                legacy.dateTimeFields.size());
+        for (int i = 0; i < canonical.dateTimeFields.size(); i++) {
+            assertEquals(
+                    canonical.dateTimeFields.get(i).type,
+                    legacy.dateTimeFields.get(i).type);
+            assertEquals(
+                    canonical.dateTimeFields.get(i).length,
+                    legacy.dateTimeFields.get(i).length);
+        }
+    }
+
+    @Test
+    public void isoDateTimeWithSubsecondPrecision() {
+        DataStylePattern pattern =
+                DataStylePattern.parse("yyyy-MM-ddTHH:mm:ss.SSS");
+        assertEquals(DataStylePattern.Kind.DATE_TIME, pattern.kind);
+        assertTrue(pattern.hasDateFields());
+
+        DataStylePattern.Field secondField = null;
+        for (DataStylePattern.Field field : pattern.dateTimeFields) {
+            if (field.type == DataStylePattern.FieldType.SECOND) {
+                secondField = field;
+            }
+        }
+        assertNotNull(secondField);
+        assertEquals(2, secondField.length);
+        assertEquals(3, secondField.decimalPlaces);
+
+        DataStylePattern.Field textT = null;
+        for (DataStylePattern.Field field : pattern.dateTimeFields) {
+            if (field.type == DataStylePattern.FieldType.TEXT
+                    && "T".equals(field.text)) {
+                textT = field;
+            }
+        }
+        assertNotNull("Expected a literal 'T' field", textT);
+    }
+
+    @Test
+    public void secondAndFractionSecondSplitMatchesDateTimeFormatter() {
+        // 's' = whole seconds, 'S' = fraction-of-second -- the exact
+        // DateTimeFormatter convention, not a case-insensitive alias of
+        // one "seconds" concept.
+        DataStylePattern pattern = DataStylePattern.parse("ss.SSS");
+        assertEquals(1, pattern.dateTimeFields.size());
+        DataStylePattern.Field second = pattern.dateTimeFields.get(0);
+        assertEquals(DataStylePattern.FieldType.SECOND, second.type);
+        assertEquals(2, second.length);
+        assertEquals(3, second.decimalPlaces);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void standaloneFractionSecondWithoutPrecedingSecondsIsRejected() {
+        // 'S' only means fraction-of-second immediately after "s." -- a
+        // bare run of 'S' with no preceding whole-seconds field has no
+        // ODF representation.
+        DataStylePattern.parse("HH:mm:SSS");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void uppercaseYIsRejected() {
+        // Uppercase 'Y' is week-based-year in real DateTimeFormatter,
+        // which ODF can't render -- it's not an alias for lowercase 'y',
+        // it's simply unsupported.
+        DataStylePattern.parse("YYYY-MM-dd");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void uppercaseDIsRejected() {
+        // Uppercase 'D' is day-of-year in real DateTimeFormatter, which
+        // ODF can't render.
+        DataStylePattern.parse("yyyy-MM-DD");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void uppercaseAIsRejectedAsUnsupportedField() {
+        // Uppercase 'A' is milli-of-day in real DateTimeFormatter, which
+        // ODF can't render -- it's not an alias for lowercase 'a', it's
+        // simply unsupported.
+        DataStylePattern.parse("yyyy-MM-dd A");
+    }
+
+    @Test
+    public void timeOnlyPatternHasNoDateFields() {
+        DataStylePattern pattern = DataStylePattern.parse("HH:mm:ss");
+        assertEquals(DataStylePattern.Kind.DATE_TIME, pattern.kind);
+        assertFalse(pattern.hasDateFields());
+    }
+
+    @Test
+    public void twelveHourClockUsesHour12FieldType() {
+        DataStylePattern pattern = DataStylePattern.parse("hh:mm a");
+        boolean sawHour12 = false;
+        boolean sawAmPm = false;
+        for (DataStylePattern.Field field : pattern.dateTimeFields) {
+            if (field.type == DataStylePattern.FieldType.HOUR12) {
+                sawHour12 = true;
+            }
+            if (field.type == DataStylePattern.FieldType.AMPM) {
+                sawAmPm = true;
+            }
+        }
+        assertTrue(sawHour12);
+        assertTrue(sawAmPm);
+    }
+
+    @Test
+    public void monthTextualFormsUseTextualLength() {
+        DataStylePattern abbrev = DataStylePattern.parse("MMM d, yyyy");
+        DataStylePattern.Field monthAbbrev = abbrev.dateTimeFields.get(0);
+        assertEquals(DataStylePattern.FieldType.MONTH, monthAbbrev.type);
+        assertEquals(3, monthAbbrev.length);
+
+        DataStylePattern full = DataStylePattern.parse("MMMM d, yyyy");
+        DataStylePattern.Field monthFull = full.dateTimeFields.get(0);
+        assertEquals(4, monthFull.length);
+    }
+
+    @Test
+    public void quotedLiteralTextIsPreservedAndUnescaped() {
+        DataStylePattern pattern =
+                DataStylePattern.parse("yyyy 'o''clock' MM");
+        StringBuilder combinedText = new StringBuilder();
+        for (DataStylePattern.Field field : pattern.dateTimeFields) {
+            if (field.type == DataStylePattern.FieldType.TEXT) {
+                combinedText.append(field.text);
+            }
+        }
+        assertTrue(combinedText.toString().contains("o'clock"));
+    }
+
+    @Test
+    public void simpleDecimalNumberPattern() {
+        DataStylePattern pattern = DataStylePattern.parse("0.00");
+        assertEquals(DataStylePattern.Kind.NUMBER, pattern.kind);
+        DataStylePattern.NumberSpec spec = pattern.numberSpec;
+        assertEquals(1, spec.minIntegerDigits);
+        assertEquals(2, spec.decimalPlaces);
+        assertFalse(spec.grouping);
+        assertFalse(spec.percentage);
+        assertEquals("", spec.prefix);
+        assertEquals("", spec.suffix);
+    }
+
+    @Test
+    public void groupedNumberPattern() {
+        DataStylePattern pattern = DataStylePattern.parse("#,##0.00");
+        DataStylePattern.NumberSpec spec = pattern.numberSpec;
+        assertTrue(spec.grouping);
+        assertEquals(1, spec.minIntegerDigits);
+        assertEquals(2, spec.decimalPlaces);
+    }
+
+    @Test
+    public void percentagePatternStripsAndReflagsPercentSign() {
+        DataStylePattern pattern = DataStylePattern.parse("0.00%");
+        DataStylePattern.NumberSpec spec = pattern.numberSpec;
+        assertTrue(spec.percentage);
+        assertEquals(2, spec.decimalPlaces);
+    }
+
+    @Test
+    public void currencyPrefixIsPreservedAsLiteralPrefix() {
+        DataStylePattern pattern = DataStylePattern.parse("$#,##0.00");
+        DataStylePattern.NumberSpec spec = pattern.numberSpec;
+        assertEquals("$", spec.prefix);
+        assertTrue(spec.grouping);
+    }
+
+    @Test
+    public void optionalDigitOnlyIntegerPartHasZeroMinDigits() {
+        DataStylePattern pattern = DataStylePattern.parse("#.00");
+        DataStylePattern.NumberSpec spec = pattern.numberSpec;
+        assertEquals(0, spec.minIntegerDigits);
+        assertEquals(2, spec.decimalPlaces);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void emptyPatternIsRejected() {
+        DataStylePattern.parse("");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void pureLiteralPatternIsRejected() {
+        DataStylePattern.parse("'Total'");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void unterminatedQuoteIsRejected() {
+        DataStylePattern.parse("yyyy-MM-dd'oops");
+    }
+
+    @Test
+    public void digitPlaceholderTakesPriorityOverStrayDateTimeLetters() {
+        // A '0'/'#' anywhere always makes the pattern NUMBER, even with
+        // date-looking letters present. This is what lets unit suffixes
+        // like "0.00 m" work unquoted. M and H are valid date/time
+        // letters elsewhere, so they're safe here -- unlike Y/D/A, which
+        // are never safe (see the tests below).
+        DataStylePattern pattern = DataStylePattern.parse("MM-0-HH");
+        assertEquals(DataStylePattern.Kind.NUMBER, pattern.kind);
+        assertEquals("MM-", pattern.numberSpec.prefix);
+        assertEquals("-HH", pattern.numberSpec.suffix);
+        assertEquals(1, pattern.numberSpec.minIntegerDigits);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void uppercaseYRejectedEvenWithDigitPlaceholderPresent() {
+        // Found by independent review: a lone digit must not let a
+        // realistic date-pattern typo (a literal day value instead of
+        // the "dd" token) silently become a garbage NUMBER pattern.
+        DataStylePattern.parse("YYYY-MM-01");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void uppercaseDRejectedEvenWithDigitPlaceholderPresent() {
+        DataStylePattern.parse("0.00-DD");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void uppercaseARejectedEvenWithDigitPlaceholderPresent() {
+        DataStylePattern.parse("0.00 A");
+    }
+
+    @Test
+    public void uppercaseWIsStillAllowedInNumberPatterns() {
+        // Unlike Y/D/A, 'W' (week-of-month) is only rejected in
+        // DATE_TIME context -- it's a plausible "Watts" unit label here.
+        DataStylePattern pattern = DataStylePattern.parse("0.00 W");
+        assertEquals(DataStylePattern.Kind.NUMBER, pattern.kind);
+        assertEquals(" W", pattern.numberSpec.suffix);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void multipleDecimalPointsAreRejected() {
+        DataStylePattern.parse("0.0.0");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void mistypedMonthTokenIsRejectedNotSilentlyTreatedAsLiteral() {
+        // 'N' is not a recognized token nor an allowed bare separator
+        // in a date/time pattern.
+        DataStylePattern.parse("yyyy-NM-dd");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void unrecognizedSymbolInDateTimePatternIsRejected() {
+        DataStylePattern.parse("yyyy@MM@dd");
+    }
+
+    @Test
+    public void quotingAnUnrecognizedCharacterMakesItValid() {
+        DataStylePattern pattern =
+                DataStylePattern.parse("yyyy'@'MM'@'dd");
+        assertEquals(DataStylePattern.Kind.DATE_TIME, pattern.kind);
+    }
+
+    // --- Stress cases for bad/illegal/invalid symbols ---
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void nullPatternIsRejected() {
+        DataStylePattern.parse(null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void whitespaceOnlyPatternIsRejected() {
+        // Spaces are an allowed bare *literal* inside a date/time
+        // pattern, but they don't themselves signal date/time or numeric
+        // intent, so a pattern with nothing else is still unrecognized.
+        DataStylePattern.parse("   ");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void patternOfOnlySeparatorCharactersIsRejected() {
+        // Every character here is an allowed bare *separator*, including
+        // the ISO 'T', but with no token letter or digit placeholder
+        // present the pattern is still unrecognized.
+        DataStylePattern.parse(" -:/.,T");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void symbolsAloneWithNoTokensAreRejected() {
+        DataStylePattern.parse("!!!");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void loneCurrencySymbolWithoutDigitPlaceholderIsRejected() {
+        // '$' alone doesn't imply a numeric pattern -- there must be at
+        // least one '0' or '#'.
+        DataStylePattern.parse("$");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void lonePercentSignWithoutDigitPlaceholderIsRejected() {
+        // '%' alone doesn't count as a numeric token either; only 0/# do.
+        DataStylePattern.parse("%");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void tabCharacterInDateTimePatternIsRejected() {
+        DataStylePattern.parse("yyyy\tMM\tdd");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void newlineCharacterInDateTimePatternIsRejected() {
+        DataStylePattern.parse("yyyy-MM-dd\n");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void unicodeSymbolInDateTimePatternIsRejected() {
+        DataStylePattern.parse("yyyy°MM°dd"); // degree sign (°)
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void emojiInDateTimePatternIsRejectedWithoutCrashing() {
+        // A surrogate-pair character must be rejected cleanly
+        // (IllegalArgumentException), not crash the tokenizer partway
+        // through the pair.
+        DataStylePattern.parse("yyyy😀MM");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void strayLetterAfterAmPmTokenIsRejected() {
+        // 'a' alone is a valid AM/PM token, but the trailing 'b' is
+        // neither a token nor an allowed bare separator.
+        DataStylePattern.parse("ab");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void oddNumberOfQuoteCharactersIsRejectedAsUnterminated() {
+        // "'''" is an opening quote, one escaped literal quote, and then
+        // no closer. Fails during quote-flattening, before letter
+        // recognition even runs.
+        DataStylePattern.parse("YYYY'''");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void unterminatedQuoteInNumericPatternIsRejected() {
+        DataStylePattern.parse("0.00'kg");
+    }
+
+    @Test
+    public void unrecognizedCharacterMessageNamesTheCharacterAndIndex() {
+        try {
+            DataStylePattern.parse("yyyy-NM-dd");
+            fail("Expected an IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("'N'"));
+            assertTrue(e.getMessage().contains("index 5"));
+        }
+    }
+
+    @Test
+    public void trailingQuotedLiteralAfterTokensParsesSuccessfully() {
+        DataStylePattern pattern =
+                DataStylePattern.parse("yyyy-MM-dd'notes'");
+        assertEquals(DataStylePattern.Kind.DATE_TIME, pattern.kind);
+        StringBuilder combinedText = new StringBuilder();
+        for (DataStylePattern.Field field : pattern.dateTimeFields) {
+            if (field.type == DataStylePattern.FieldType.TEXT) {
+                combinedText.append(field.text);
+            }
+        }
+        assertTrue(combinedText.toString().contains("notes"));
+    }
+
+    @Test
+    public void numericPatternToleratesUnusualUnquotedLiteralSymbols() {
+        // Numeric patterns are deliberately more permissive than
+        // date/time ones: unquoted prefix/suffix decoration is common
+        // and unambiguous there, with no letter-token-confusion risk.
+        DataStylePattern pattern = DataStylePattern.parse("0.00 µs");
+        assertEquals(DataStylePattern.Kind.NUMBER, pattern.kind);
+        assertTrue(pattern.numberSpec.suffix.contains("µs"));
+    }
+
+    // Note: an integration test confirming Style.setDataStyle delegates
+    // to DataStylePattern.parse belongs in the PR that actually wires
+    // that delegation up (Style.java is untouched here).
+
+    // --- Hour / AM-PM pairing ---
+    // ODF has no attribute distinguishing 12h from 24h; it's governed
+    // purely by whether a number:am-pm sibling is present.
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void hour12WithoutAmPmMarkerIsRejected() {
+        // Without 'a', ODF would render this identically to a 24-hour
+        // clock, silently contradicting the 'h' the user wrote.
+        DataStylePattern.parse("hh:mm");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void hour24WithAmPmMarkerIsRejected() {
+        // ODF always renders 12-hour whenever an AM/PM marker is
+        // present, silently contradicting the 'H' the user wrote.
+        DataStylePattern.parse("HH:mm a");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void mixingHour12AndHour24TokensIsRejected() {
+        DataStylePattern.parse("hh:HH");
+    }
+
+    @Test
+    public void hour12WithAmPmMarkerParsesSuccessfully() {
+        DataStylePattern pattern = DataStylePattern.parse("hh:mm a");
+        assertEquals(DataStylePattern.Kind.DATE_TIME, pattern.kind);
+    }
+
+    @Test
+    public void hour24WithoutAmPmMarkerParsesSuccessfully() {
+        DataStylePattern pattern = DataStylePattern.parse("HH:mm");
+        assertEquals(DataStylePattern.Kind.DATE_TIME, pattern.kind);
+    }
+
+    // --- Era / day-of-week / week-of-year / quarter ---
+    // Confirmed against the ODF 1.2 RelaxNG schema.
+
+    @Test
+    public void eraFieldParsesAndCountsAsDateField() {
+        DataStylePattern shortEra = DataStylePattern.parse("G yyyy");
+        assertEquals(
+                DataStylePattern.FieldType.ERA,
+                shortEra.dateTimeFields.get(0).type);
+        assertTrue(shortEra.hasDateFields());
+
+        DataStylePattern longEra = DataStylePattern.parse("GGGG yyyy");
+        assertEquals(4, longEra.dateTimeFields.get(0).length);
+    }
+
+    @Test
+    public void dayOfWeekFieldParsesAndCountsAsDateField() {
+        DataStylePattern pattern = DataStylePattern.parse("EEE, MMM d");
+        assertEquals(
+                DataStylePattern.FieldType.DAY_OF_WEEK,
+                pattern.dateTimeFields.get(0).type);
+        assertTrue(pattern.hasDateFields());
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void lowercaseDayOfWeekLettersAreRejected() {
+        // 'e'/'c' can mean a numeric weekday number at low repeat
+        // counts, which ODF cannot render; only always-textual
+        // uppercase 'E' is supported.
+        DataStylePattern.parse("yyyy-MM-dd e");
+    }
+
+    @Test
+    public void weekOfYearFieldIgnoresRepeatCount() {
+        // ODF's number:week-of-year has no style attribute at all.
+        DataStylePattern pattern = DataStylePattern.parse("w yyyy");
+        assertEquals(
+                DataStylePattern.FieldType.WEEK_OF_YEAR,
+                pattern.dateTimeFields.get(0).type);
+        assertTrue(pattern.hasDateFields());
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void weekOfMonthIsRejected() {
+        // Uppercase 'W' (week-of-month) is a different DateTimeFormatter
+        // field from 'w' (week-of-year) with no ODF element at all.
+        DataStylePattern.parse("yyyy-MM-dd W");
+    }
+
+    @Test
+    public void quarterAcceptsBothCasesAsTheSameField() {
+        DataStylePattern upper = DataStylePattern.parse("Q yyyy");
+        DataStylePattern lower = DataStylePattern.parse("q yyyy");
+        assertEquals(
+                DataStylePattern.FieldType.QUARTER,
+                upper.dateTimeFields.get(0).type);
+        assertEquals(
+                DataStylePattern.FieldType.QUARTER,
+                lower.dateTimeFields.get(0).type);
+    }
+
+    @Test
+    public void quarterLongFormIsTextual() {
+        DataStylePattern shortQuarter = DataStylePattern.parse("Q yyyy");
+        assertEquals(1, shortQuarter.dateTimeFields.get(0).length);
+
+        DataStylePattern longQuarter = DataStylePattern.parse("QQQ yyyy");
+        assertEquals(3, longQuarter.dateTimeFields.get(0).length);
+    }
+
+    // --- Scientific notation ---
+    // "E", matching java.text.DecimalFormat's own convention.
+
+    @Test
+    public void scientificNotationParsesMantissaAndExponent() {
+        DataStylePattern pattern = DataStylePattern.parse("0.00E00");
+        assertEquals(DataStylePattern.Kind.NUMBER, pattern.kind);
+        DataStylePattern.NumberSpec spec = pattern.numberSpec;
+        assertTrue(spec.scientific);
+        assertEquals(1, spec.minIntegerDigits);
+        assertEquals(2, spec.decimalPlaces);
+        assertEquals(2, spec.minExponentDigits);
+    }
+
+    @Test
+    public void scientificNotationWithSingleExponentDigit() {
+        DataStylePattern pattern = DataStylePattern.parse("0.###E0");
+        DataStylePattern.NumberSpec spec = pattern.numberSpec;
+        assertTrue(spec.scientific);
+        assertEquals(3, spec.decimalPlaces);
+        assertEquals(1, spec.minExponentDigits);
+    }
+
+    @Test
+    public void scientificNotationWithSuffixLiteralContainingE() {
+        // Only the FIRST unquoted 'E' triggers scientific mode; a later
+        // literal 'E' (e.g. in a unit label) is just ordinary suffix
+        // text.
+        DataStylePattern pattern =
+                DataStylePattern.parse("0.00E00 EUR");
+        DataStylePattern.NumberSpec spec = pattern.numberSpec;
+        assertTrue(spec.scientific);
+        assertEquals(" EUR", spec.suffix);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void scientificNotationWithoutExponentDigitsIsRejected() {
+        DataStylePattern.parse("0.00E");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void scientificNotationCombinedWithPercentageIsRejected() {
+        // ODF's number:percentage-style content model only allows a
+        // plain number:number child, not number:scientific-number.
+        DataStylePattern.parse("0.00E00%");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void scientificNotationWithoutMantissaDigitIsRejected() {
+        DataStylePattern.parse("E00");
+    }
+}


### PR DESCRIPTION
Add new `DataStylePattern` class that will parse date/time and number pattern string and give an object that can be used later to construct ODS XML output.

This PR only has the new `DataStylePattern` class and a test suite for it, so we can review the code and the proposed pattern string (compatible with ones that used by Java's `DateTimeFormatter` and `DecimalFormatter` - with few limitations).

Nothing is actually written to the ODS output by the changes in this PR.
(Planned to be in next PRs if the proposed native Java-compatible pattern get approved).