### PR TITLE
Update license name and URL in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
 
   <licenses>
     <license>
-      <name>The Unlicense</name>
-      <url>https://github.com/miachm/SODS/blob/master/LICENSE</url>
+      <name>Unlicense</name>
+      <url>https://unlicense.org/</url>
       <distribution>repo</distribution>
     </license>
   </licenses>


### PR DESCRIPTION
Fixes #109

Note - the URL has a trailing `/` to match the [SPDX license metadata for Unlicense](https://spdx.org/licenses/Unlicense.html).